### PR TITLE
feat: remove editor from bundle

### DIFF
--- a/.yarn/versions/11570002.yml
+++ b/.yarn/versions/11570002.yml
@@ -1,2 +1,5 @@
 releases:
   "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns

--- a/.yarn/versions/11570002.yml
+++ b/.yarn/versions/11570002.yml
@@ -1,0 +1,2 @@
+releases:
+  "@nimbus-ds/patterns": patch

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2023-11-16 `1.7.3`
+
+#### 💡 Others
+
+- Remove `Editor` component from bundle until `lexical` supports SSR to prevent erros with server-side rendering projects. ([#86](https://github.com/TiendaNube/nimbus-patterns/pull/86) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-11-15 `1.7.2`
 
 #### 📚 3rd party library updates

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/patterns",
-  "version": "1.7.2",
+  "version": "1.7.3-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -34,5 +34,6 @@
   },
   "bugs": {
     "url": "https://github.com/TiendaNube/nimbus-patterns/issues"
-  }
+  },
+  "stableVersion": "1.7.2"
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,7 +3,7 @@ export * from "@nimbus-ds/app-shell";
 export * from "@nimbus-ds/callout-card";
 export * from "@nimbus-ds/data-list";
 export * from "@nimbus-ds/data-table";
-export * from "@nimbus-ds/editor";
+// export * from "@nimbus-ds/editor"; Remove from package until lexical supports SSR
 export * from "@nimbus-ds/empty-message";
 export * from "@nimbus-ds/formfield";
 export * from "@nimbus-ds/help-link";


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/patterns@1.7.3`

#### 💡 Others

- Remove `Editor` component from bundle until `lexical` supports SSR to prevent erros with server-side rendering projects. ([#86](https://github.com/TiendaNube/nimbus-patterns/pull/86) by [@juanchigallego](https://github.com/juanchigallego))
