### PR TITLE
Fix/formfield export types

### DIFF
--- a/.yarn/versions/72a5784c.yml
+++ b/.yarn/versions/72a5784c.yml
@@ -1,0 +1,11 @@
+releases:
+  "@nimbus-ds/formfield": patch
+  "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns
+  - "@nimbus-ds/app-shell"
+  - "@nimbus-ds/callout-card"
+  - "@nimbus-ds/menu"
+  - "@nimbus-ds/menubutton"
+  - "@nimbus-ds/sidemodal"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
-## 2023-12-22 `1.7.6`
+## 2024-01-04 `1.7.6`
+
+#### 🐛 Bug fixes
+
+- Explicitly export type for `FormFieldInput` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
+- Explicitly export type for `FormFieldSelect` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
+- Explicitly export type for `FormFieldTextarea` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
 
 #### 🎉 New features
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/patterns",
-  "version": "1.7.5-rc.4",
+  "version": "1.7.6-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -35,5 +35,5 @@
   "bugs": {
     "url": "https://github.com/TiendaNube/nimbus-patterns/issues"
   },
-  "stableVersion": "1.7.4"
+  "stableVersion": "1.7.5"
 }

--- a/packages/react/src/components/AppShell/package.json
+++ b/packages/react/src/components/AppShell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/app-shell",
-  "version": "1.4.1-rc.4",
+  "version": "1.4.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -33,6 +33,5 @@
     "@nimbus-ds/menu": "workspace:^",
     "@nimbus-ds/menubutton": "workspace:^",
     "@nimbus-ds/page": "workspace:^"
-  },
-  "stableVersion": "1.4.0"
+  }
 }

--- a/packages/react/src/components/CalloutCard/package.json
+++ b/packages/react/src/components/CalloutCard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/callout-card",
-  "version": "1.6.4-rc.4",
+  "version": "1.6.4",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -28,6 +28,5 @@
   },
   "bugs": {
     "url": "https://github.com/TiendaNube/nimbus-patterns/issues"
-  },
-  "stableVersion": "1.6.3"
+  }
 }

--- a/packages/react/src/components/FormField/CHANGELOG.md
+++ b/packages/react/src/components/FormField/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 The FormField component allows the user to enter or edit information in text format. Additionally, it provides a label, and a conditional help text that can be used to provide additional context on a validation scenario.
 
+## 2024-01-04 `1.6.4`
+
+#### 🐛 Bug fixes
+
+- Explicitly export type for `FormFieldInput` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
+- Explicitly export type for `FormFieldSelect` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
+- Explicitly export type for `FormFieldTextarea` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
+
 ## 2023-12-06 `1.6.2`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/components/FormField/package.json
+++ b/packages/react/src/components/FormField/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/formfield",
-  "version": "1.6.3-rc.4",
+  "version": "1.6.4-rc.1",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -31,5 +31,5 @@
   "devDependencies": {
     "@nimbus-ds/icons": "^1"
   },
-  "stableVersion": "1.6.2"
+  "stableVersion": "1.6.3"
 }

--- a/packages/react/src/components/FormField/src/components/FormFieldInput/index.ts
+++ b/packages/react/src/components/FormField/src/components/FormFieldInput/index.ts
@@ -1,4 +1,5 @@
 import { FormFieldInput } from "./FormFieldInput";
 
 export { FormFieldInput } from "./FormFieldInput";
+export type { FormFieldInputProps } from "./FormFieldInput";
 export default FormFieldInput;

--- a/packages/react/src/components/FormField/src/components/FormFieldSelect/index.ts
+++ b/packages/react/src/components/FormField/src/components/FormFieldSelect/index.ts
@@ -1,4 +1,5 @@
 import { FormFieldSelect } from "./FormFieldSelect";
 
 export { FormFieldSelect } from "./FormFieldSelect";
+export type { FormFieldSelectProps } from "./FormFieldSelect";
 export default FormFieldSelect;

--- a/packages/react/src/components/FormField/src/components/FormFieldTextarea/index.ts
+++ b/packages/react/src/components/FormField/src/components/FormFieldTextarea/index.ts
@@ -1,4 +1,5 @@
 import { FormFieldTextarea } from "./FormFieldTextarea";
 
 export { FormFieldTextarea } from "./FormFieldTextarea";
+export type { FormFieldTextareaProps } from "./FormFieldTextarea";
 export default FormFieldTextarea;

--- a/packages/react/src/components/FormField/src/index.ts
+++ b/packages/react/src/components/FormField/src/index.ts
@@ -2,4 +2,7 @@ import { FormField } from "./FormField";
 
 export { FormField } from "./FormField";
 export type { FormFieldProps } from "./formField.types";
+export type { FormFieldInputProps } from "./components/FormFieldInput";
+export type { FormFieldSelectProps } from "./components/FormFieldSelect";
+export type { FormFieldTextareaProps } from "./components/FormFieldTextarea";
 export default FormField;

--- a/packages/react/src/components/Menu/package.json
+++ b/packages/react/src/components/Menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/menu",
-  "version": "1.5.3-rc.5",
+  "version": "1.5.3",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -31,6 +31,5 @@
   },
   "dependencies": {
     "@nimbus-ds/menubutton": "workspace:^"
-  },
-  "stableVersion": "1.5.2"
+  }
 }

--- a/packages/react/src/components/MenuButton/package.json
+++ b/packages/react/src/components/MenuButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/menubutton",
-  "version": "1.5.3-rc.5",
+  "version": "1.5.3",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -33,6 +33,5 @@
   },
   "devDependencies": {
     "@nimbus-ds/icons": "^1"
-  },
-  "stableVersion": "1.5.2"
+  }
 }

--- a/packages/react/src/components/SideModal/package.json
+++ b/packages/react/src/components/SideModal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/sidemodal",
-  "version": "1.7.4-rc.4",
+  "version": "1.7.4",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -30,6 +30,5 @@
   },
   "devDependencies": {
     "@nimbus-ds/icons": "^1"
-  },
-  "stableVersion": "1.7.3"
+  }
 }


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/patterns@1.7.6`

#### 🐛 Bug fixes

- Explicitly export type for `FormFieldInput` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
- Explicitly export type for `FormFieldSelect` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
- Explicitly export type for `FormFieldTextarea` component. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))

#### 🎉 New features

- Update `AppShell` component with new design requirements. ([#91](https://github.com/TiendaNube/nimbus-patterns/pull/91) by [@juanchigallego](https://github.com/juanchigallego))
- Update `CalloutCard` component with new design requirements. ([#91](https://github.com/TiendaNube/nimbus-patterns/pull/91) by [@juanchigallego](https://github.com/juanchigallego))
- Update `SideModal` component with new design requirements. ([#91](https://github.com/TiendaNube/nimbus-patterns/pull/91) by [@juanchigallego](https://github.com/juanchigallego))

## `@nimbus-ds/formfield@1.6.4`

#### 🐛 Bug fixes

- Explicitly export type for `FormFieldInput` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
- Explicitly export type for `FormFieldSelect` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))
- Explicitly export type for `FormFieldTextarea` subcomponent. ([#92](https://github.com/TiendaNube/nimbus-patterns/pull/92) by [@juanchigallego](https://github.com/juanchigallego))