### PR TITLE
Feat/menubutton word break ecnim 909

### DIFF
--- a/.yarn/versions/42cf25fa.yml
+++ b/.yarn/versions/42cf25fa.yml
@@ -1,0 +1,10 @@
+releases:
+  "@nimbus-ds/menubutton": patch
+  "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns
+  - "@nimbus-ds/app-shell"
+  - "@nimbus-ds/calendar"
+  - "@nimbus-ds/editor"
+  - "@nimbus-ds/menu"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,7 +6,7 @@ Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s tea
 
 ### 🎉 New features
 
-- Add `wordBreak="break-all"` property to `MenuButton` component to allow overflowing text to be trimmed at any position.
+- Add `wordBreak="break-all"` property to `MenuButton` component to allow overflowing text to be trimmed at any position. ([#94](https://github.com/TiendaNube/nimbus-patterns/pull/94) by [@juanchigallego](https://github.com/juanchigallego))
 
 ## 2024-01-09 `1.7.7`
 

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2024-02-07 `1.7.8`
+
+### 🎉 New features
+
+- Add `wordBreak="break-all"` property to `MenuButton` component to allow overflowing text to be trimmed at any position.
+
 ## 2024-01-09 `1.7.7`
 
 #### 🐛 Bug fixes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/patterns",
-  "version": "1.7.6",
+  "version": "1.7.7",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",

--- a/packages/react/src/components/MenuButton/CHANGELOG.md
+++ b/packages/react/src/components/MenuButton/CHANGELOG.md
@@ -6,7 +6,7 @@ MenuButton component is meant to be used inside Menus and navigation, and allows
 
 ### 🎉 New features
 
-- Add `wordBreak="break-all"` property to allow overflowing text to be trimmed at any position.
+- Add `wordBreak="break-all"` property to allow overflowing text to be trimmed at any position. ([#94](https://github.com/TiendaNube/nimbus-patterns/pull/94) by [@juanchigallego](https://github.com/juanchigallego))
 
 ## 2024-01-09 `1.5.4`
 

--- a/packages/react/src/components/MenuButton/CHANGELOG.md
+++ b/packages/react/src/components/MenuButton/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 MenuButton component is meant to be used inside Menus and navigation, and allows the user to navigate between different sections of an application.
 
+## 2024-02-07 `1.5.5`
+
+### 🎉 New features
+
+- Add `wordBreak="break-all"` property to allow overflowing text to be trimmed at any position.
+
 ## 2024-01-09 `1.5.4`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/components/MenuButton/package.json
+++ b/packages/react/src/components/MenuButton/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nimbus-ds/menubutton",
-  "version": "1.5.4-rc.1",
+  "version": "1.5.4",
   "license": "MIT",
   "source": "src/index.ts",
   "main": "dist/index.js",
@@ -33,6 +33,5 @@
   },
   "devDependencies": {
     "@nimbus-ds/icons": "^1"
-  },
-  "stableVersion": "1.5.3"
+  }
 }

--- a/packages/react/src/components/MenuButton/src/MenuButton.tsx
+++ b/packages/react/src/components/MenuButton/src/MenuButton.tsx
@@ -65,7 +65,12 @@ const MenuButton = forwardRef(
           <Icon color={disabledColor} source={<IconSrc size={14} />} />
         )}
         <Box display="inline-flex" flex="1">
-          <Text fontSize="base" color={disabledColor} lineClamp={1}>
+          <Text
+            fontSize="base"
+            color={disabledColor}
+            lineClamp={1}
+            wordBreak="break-all"
+          >
             {label}
           </Text>
         </Box>

--- a/packages/react/src/components/MenuButton/src/menuButton.stories.tsx
+++ b/packages/react/src/components/MenuButton/src/menuButton.stories.tsx
@@ -8,9 +8,7 @@ import { Tag, Badge, Icon } from "@nimbus-ds/components";
 import { MenuButton, MenuButtonProps } from "./MenuButton";
 
 export const Basic: React.FC<MenuButtonProps> = forwardRef(
-  ({ children = "Button", ...props }: MenuButtonProps) => (
-    <MenuButton {...props}>{children}</MenuButton>
-  )
+  ({ ...props }: MenuButtonProps) => <MenuButton {...props} />
 ) as React.FC<MenuButtonProps>;
 Basic.displayName = "MenuButton";
 
@@ -42,6 +40,14 @@ export const sampleAppMenuButton: Story = {
   args: {
     label: "Menu button",
     startIcon: HomeIcon,
+  },
+};
+
+export const stressedAppMenuButton: Story = {
+  args: {
+    label: "This is a very stressed menu button with a very long text to showcase what happens when the text overflows the button",
+    startIcon: HomeIcon,
+    children: <Tag appearance="primary">Children tag</Tag>
   },
 };
 


### PR DESCRIPTION
## Type

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

## `@nimbus-ds/patterns@1.7.8`

### 🎉 New features

- Add `wordBreak="break-all"` property to `MenuButton` component to allow overflowing text to be trimmed at any position. ([#94](https://github.com/TiendaNube/nimbus-patterns/pull/94) by [@juanchigallego](https://github.com/juanchigallego))

## `@nimbus-ds/menubutton@1.5.5`

### 🎉 New features

- Add `wordBreak="break-all"` property to allow overflowing text to be trimmed at any position. ([#94](https://github.com/TiendaNube/nimbus-patterns/pull/94) by [@juanchigallego](https://github.com/juanchigallego))