### PR TITLE
NIMBUS-16 - Fix PlanDisplay component not in bundle 1.9.0

### DIFF
--- a/.yarn/versions/7ca8b38e.yml
+++ b/.yarn/versions/7ca8b38e.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/patterns": patch
+  "@nimbus-ds/plan-display": patch
+
+undecided:
+  - nimbus-patterns

--- a/.yarn/versions/7ca8b38e.yml
+++ b/.yarn/versions/7ca8b38e.yml
@@ -2,5 +2,5 @@ releases:
   "@nimbus-ds/patterns": patch
   "@nimbus-ds/plan-display": patch
 
-undecided:
+declined:
   - nimbus-patterns

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2024-02-17 `1.9.1`
+
+- Fixed `PlanDisplay` not being exported and not working on NextJS. ([#99](https://github.com/TiendaNube/nimbus-patterns/pull/99) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2024-02-17 `1.9.0`
 
 - Added new `PlanDisplay` component. ([#98](https://github.com/TiendaNube/nimbus-patterns/pull/98) by [@joacotornello](https://github.com/joacotornello))

--- a/packages/react/src/components/PlanDisplay/CHANGELOG.md
+++ b/packages/react/src/components/PlanDisplay/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 EmptyApp allows the user to build marketing-style landing pages for apps. It features internal components meant to build hero sections, content sections with images and text with features, and payment plans.
+
+## 2024-03-06 `1.0.1`
+
+- Fixed `PlanDisplay` not working on NextJS because of PlanDisplayBullet not being HTML semantically correct. ([#99](https://github.com/TiendaNube/nimbus-patterns/pull/99) by [@joacotornello](https://github.com/joacotornello))

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
@@ -9,7 +9,10 @@ const PlanDisplayBullet: React.FC<PlanDisplayBulletProps> = ({
 }) => (
   <Box display="flex" gap="2">
     <Box display="flex" alignItems="center">
-      <Text color={disabled ? "neutral-interactive" : "success-interactive"}>
+      <Text
+        as="span"
+        color={disabled ? "neutral-interactive" : "success-interactive"}
+      >
         <Box display="flex" alignItems="center">
           {icon}
         </Box>

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
@@ -5,6 +5,7 @@ import { PlanDisplayCardProps } from "./planDisplayCard.types";
 const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
   highlighted,
   children,
+  ...rest
 }) => {
   const highlightedProps: BoxProps = {
     borderColor: "primary-interactive",
@@ -15,7 +16,7 @@ const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
   };
 
   return (
-    <Box {...(highlighted ? highlightedProps : {})}>
+    <Box {...(highlighted ? highlightedProps : {})} {...rest}>
       <Card>{children}</Card>
     </Box>
   );

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.types.ts
@@ -1,6 +1,11 @@
+import { BoxProps } from "@nimbus-ds/components";
 import { PropsWithChildren } from "react";
 
 type CardProps = {
   highlighted?: boolean;
 };
-export type PlanDisplayCardProps = PropsWithChildren<CardProps>;
+export type PlanDisplayCardProps = PropsWithChildren<CardProps> &
+  Omit<
+    BoxProps,
+    "borderColor" | "borderRadius" | "borderStyle" | "borderWidth" | "boxShadow"
+  >;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,3 +18,4 @@ export * from "@nimbus-ds/sidemodal";
 export * from "@nimbus-ds/thumbnail-with-action";
 export * from "@nimbus-ds/calendar";
 export * from "@nimbus-ds/empty-app";
+export * from "@nimbus-ds/plan-display";


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛

## Changes proposed ✔️
Added component to bundle, exporting it in the index.ts and fixed a bug in NextJS hydration, via solving HTML semantic issue