### PR TITLE
fix: AppShell menuExpanded prop should default to true

### DIFF
--- a/.yarn/versions/6887b557.yml
+++ b/.yarn/versions/6887b557.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/app-shell": patch
+  "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-09-10 `1.20.1`
+
+#### 🐛 Bug fixes
+
+- Fixed `AppShell` default value for `menuExpanded` prop to be true. ([#121](https://github.com/TiendaNube/nimbus-patterns/pull/121) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-04 `1.20.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/AppShell/CHANGELOG.md
+++ b/packages/react/src/components/AppShell/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AppShell component is the main outer frame of an application. It provides the basic architecture to build an application inside of our admin.
 
+## 2025-09-10 `1.6.1`
+
+#### 🐛 Bug fixes
+
+- Fixed default value for `menuExpanded` prop to be true. ([#121](https://github.com/TiendaNube/nimbus-patterns/pull/121) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-04 `1.6.0`
 
 #### 💡 Others

--- a/packages/react/src/components/AppShell/src/AppShell.tsx
+++ b/packages/react/src/components/AppShell/src/AppShell.tsx
@@ -29,7 +29,7 @@ const AppShell: React.FC<AppShellProps> & AppShellComponents = ({
       md: "block",
     },
   },
-  menuExpanded,
+  menuExpanded = true,
   menuExpandedWidth = "240px",
   menuCollapsedWidth = "48px",
   menuBehavior = "inline",

--- a/packages/react/src/components/AppShell/src/appShell.stories.tsx
+++ b/packages/react/src/components/AppShell/src/appShell.stories.tsx
@@ -331,10 +331,11 @@ export const collapsibleMenuHover: Story = {
         menuBehavior="popover"
         menuFlyout={{ trigger: "hover", open, onOpenChange: setOpen }}
         menu={<AppMenu menuExpanded={open} />}
+        menuExpanded={false}
       >
         <AppShell.Header rightSlot={buttonStack} />
         <Page maxWidth="800px">
-          <Page.Header title="Rail with click popover" />
+          <Page.Header title="Rail with hover popover" />
           <Page.Body>
             <Box
               backgroundColor="primary-surface"
@@ -349,7 +350,7 @@ export const collapsibleMenuHover: Story = {
               justifyContent="center"
             >
               <Text fontSize="base" color="primary-interactive">
-                Use the button inside the rail to toggle the overlay menu
+                Hover the left menu to toggle the overlay menu
               </Text>
             </Box>
           </Page.Body>
@@ -446,6 +447,7 @@ export const collapsibleMenuClick: Story = {
         menuBehavior="popover"
         menuFlyout={{ trigger: "manual", open, onOpenChange: setOpen }}
         menu={<AppClickMenu defaultExpanded={open} />}
+        menuExpanded={false}
       >
         <AppShell.Header rightSlot={buttonStack} />
         <Page maxWidth="800px">

--- a/packages/react/src/components/AppShell/src/appShell.types.ts
+++ b/packages/react/src/components/AppShell/src/appShell.types.ts
@@ -15,7 +15,7 @@ export interface AppShellComponents {
  * while keeping individual top-level props for backward compatibility.
  */
 export type AppShellMenuFlyoutOptions = {
-  /** How the popover opens. Defaults to 'hover'. */
+  /** How the popover opens. Defaults to 'manual'. */
   trigger?: "hover" | "manual";
   /** Controlled open state for the flyout. */
   open?: boolean;
@@ -49,11 +49,11 @@ export interface AppShellProperties {
    */
   menuExpanded?: boolean;
   /**
-   * Sidebar width when expanded. Defaults to "18rem".
+   * Sidebar width when expanded. Defaults to "240px".
    */
   menuExpandedWidth?: BoxBaseProps["width"];
   /**
-   * Sidebar width when collapsed (rail). If provided, the sidebar will render in a compact rail while collapsed. Defaults to "4.5rem".
+   * Sidebar width when collapsed (rail). If provided, the sidebar will render in a compact rail while collapsed. Defaults to "48px".
    */
   menuCollapsedWidth?: BoxBaseProps["width"];
 

--- a/packages/react/src/components/AppShell/src/appShell.types.ts
+++ b/packages/react/src/components/AppShell/src/appShell.types.ts
@@ -45,7 +45,7 @@ export interface AppShellProperties {
    */
   menuProperties?: Pick<BoxBaseProps, "display">;
   /**
-   * Controls whether the left sidebar (menu) is expanded (true) or collapsed (false).
+   * Controls whether the left sidebar (menu) is expanded (true) or collapsed (false). Defaults to true.
    */
   menuExpanded?: boolean;
   /**


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - AppShell’s side menu now expands by default when no preference is provided, resolving unintended collapsed state in layouts.

- Documentation
  - Updated component docs and CHANGELOG to reflect the default menuExpanded behavior (defaults to true).
  - Refreshed Storybook examples to explicitly showcase collapsed variants and clarified hover vs. click descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->