### PR TITLE
fix: added optional enforce parameter to useAppShellMenuContext hook

### DIFF
--- a/.yarn/versions/01c4b9db.yml
+++ b/.yarn/versions/01c4b9db.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/app-shell": minor
+  "@nimbus-ds/patterns": minor
+
+declined:
+  - nimbus-patterns

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-09-27 `1.23.0`
+
+#### 🎉 New features
+
+- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#124](https://github.com/TiendaNube/nimbus-patterns/pull/124) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-27 `1.22.0`
 
 #### 🎉 New features

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -6,7 +6,7 @@ Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s tea
 
 #### 🎉 New features
 
-- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#124](https://github.com/TiendaNube/nimbus-patterns/pull/124) by [@joacotornello](https://github.com/joacotornello))
+- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#125](https://github.com/TiendaNube/nimbus-patterns/pull/125) by [@joacotornello](https://github.com/joacotornello))
 
 ## 2025-09-27 `1.22.0`
 

--- a/packages/react/src/components/AppShell/CHANGELOG.md
+++ b/packages/react/src/components/AppShell/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AppShell component is the main outer frame of an application. It provides the basic architecture to build an application inside of our admin.
 
+## 2025-09-27 `1.8.0`
+
+#### 🎉 New features
+
+- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#124](https://github.com/TiendaNube/nimbus-patterns/pull/124) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-27 `1.7.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/AppShell/CHANGELOG.md
+++ b/packages/react/src/components/AppShell/CHANGELOG.md
@@ -6,7 +6,7 @@ The AppShell component is the main outer frame of an application. It provides th
 
 #### 🎉 New features
 
-- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#124](https://github.com/TiendaNube/nimbus-patterns/pull/124) by [@joacotornello](https://github.com/joacotornello))
+- Added `enforce` parameter to `useAppShellMenuContext` hook to allow for optional use without a provider. ([#125](https://github.com/TiendaNube/nimbus-patterns/pull/125) by [@joacotornello](https://github.com/joacotornello))
 
 ## 2025-09-27 `1.7.0`
 

--- a/packages/react/src/components/AppShell/src/appShell.spec.tsx
+++ b/packages/react/src/components/AppShell/src/appShell.spec.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, renderHook, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Box } from "@nimbus-ds/components";
@@ -80,5 +80,9 @@ describe("GIVEN <AppShell />", () => {
     await userEvent.keyboard("{Escape}");
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not throw error when useAppShellMenuContext is used without a provider", () => {
+    expect(() => renderHook(() => useAppShellMenuContext(false))).not.toThrow();
   });
 });

--- a/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.definitions.ts
+++ b/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.definitions.ts
@@ -1,0 +1,5 @@
+import { AppShellMenuContextValue } from "./AppShellMenuContext.types";
+
+export const initialAppShellMenuContextValue: AppShellMenuContextValue = {
+  isMenuPopover: false,
+} as const;

--- a/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.ts
+++ b/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.ts
@@ -1,14 +1,19 @@
 import { createContext, useContext } from "react";
 import { AppShellMenuContextValue } from "./AppShellMenuContext.types";
+import { initialAppShellMenuContextValue } from "./AppShellMenuContext.definitions";
 
 export const AppShellMenuContext = createContext<
   AppShellMenuContextValue | undefined
 >(undefined);
 
-export const useAppShellMenuContext = () => {
+export const useAppShellMenuContext = (enforce = true) => {
   const context = useContext(AppShellMenuContext);
 
   if (context === undefined) {
+    if (!enforce) {
+      return initialAppShellMenuContextValue;
+    }
+
     throw new Error(
       "useAppShellMenuContext must be used within an AppShell Menu"
     );

--- a/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.ts
+++ b/packages/react/src/components/AppShell/src/contexts/AppShellMenuContext/AppShellMenuContext.ts
@@ -6,6 +6,11 @@ export const AppShellMenuContext = createContext<
   AppShellMenuContextValue | undefined
 >(undefined);
 
+/**
+ * Read AppShellMenuContext state. Useful to know if the menu is rendered as a popover/flyout.
+ * @param enforce When false, returns a default value (false) if no provider is present. Adviced not to abuse, but useful for menu that Menu components that aren't always inside an AppShell.
+ * @throws If `enforce=true` and used without a provider.
+ */
 export const useAppShellMenuContext = (enforce = true) => {
   const context = useContext(AppShellMenuContext);
 


### PR DESCRIPTION
## Type

- [ ] Bugfix 🐛
- [x] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App Shell menu context hook now supports optional use without a provider via a new enforce option (defaults to strict behavior).

* **Documentation**
  * Updated React and App Shell changelogs with version entries describing the new hook option.

* **Tests**
  * Added tests confirming the hook can be safely called without a provider when using the new option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->