### PR TITLE
fix: disable hook enforcement to ensure retro-compatibility

### DIFF
--- a/.yarn/versions/9fd8fd72.yml
+++ b/.yarn/versions/9fd8fd72.yml
@@ -1,0 +1,7 @@
+releases:
+  "@nimbus-ds/menu": patch
+  "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns
+  - "@nimbus-ds/app-shell"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-09-28 `1.23.1`
+
+#### 💡 Others
+
+- Disabled enforce check for `useMenuExpandContext` hook to ensure backward compatibility with clients that were not using the `<Menu>` component as wrapper of `Menu` subcomponents. ([#126](https://github.com/TiendaNube/nimbus-patterns/pull/126) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-27 `1.23.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/Menu/CHANGELOG.md
+++ b/packages/react/src/components/Menu/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The Menu component allows the user to create in-app menus that navigate through different sections of an application.
 
+## 2025-09-28 `1.6.1`
+
+#### 💡 Others
+
+- Disabled enforce check for `useMenuExpandContext` hook to ensure backward compatibility with clients that were not using the `<Menu>` component as wrapper of `Menu` subcomponents. ([#126](https://github.com/TiendaNube/nimbus-patterns/pull/126) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-08-08 `1.6.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/Menu/src/components/MenuHeader/MenuHeader.tsx
+++ b/packages/react/src/components/Menu/src/components/MenuHeader/MenuHeader.tsx
@@ -11,7 +11,7 @@ const MenuHeader: React.FC<MenuHeaderProps> = ({
   children,
   ...rest
 }: MenuHeaderProps) => {
-  const { expanded } = useMenuExpandContext();
+  const { expanded } = useMenuExpandContext(false);
 
   const dynamicProps: BoxProperties = useMemo(
     () =>

--- a/packages/react/src/components/Menu/src/components/MenuSection/MenuSection.tsx
+++ b/packages/react/src/components/Menu/src/components/MenuSection/MenuSection.tsx
@@ -12,7 +12,7 @@ const MenuSection: React.FC<MenuSectionProps> = ({
   children,
   ...rest
 }: MenuSectionProps) => {
-  const { expanded } = useMenuExpandContext();
+  const { expanded } = useMenuExpandContext(false);
 
   const dynamicProps: BoxProperties = useMemo(
     () =>


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️
- As some clients were using wrongly our Menu pattern (using some parts of the pattern without the wrapper) this resulted on the Provider not being constructed. Disabled the enforcement for now, and in the future we'll add warnings and document the correct usage for patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Restores backward compatibility: Menu subcomponents no longer require a parent Menu wrapper to function correctly.
  - Harmonizes MenuHeader and MenuSection layout/padding to consistently reflect expanded vs. collapsed states, improving visual consistency.

- Documentation
  - Added changelog entries (2025-09-28) for versions 1.23.1 and 1.6.1 describing the behavioral update and compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->