### PR TITLE
fix: appshell not showing scrollbar when content overflowing on screen

### DIFF
--- a/.yarn/versions/7eef2aba.yml
+++ b/.yarn/versions/7eef2aba.yml
@@ -1,0 +1,6 @@
+releases:
+  "@nimbus-ds/app-shell": patch
+  "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop’s team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2025-09-30 `1.23.3`
+
+#### 🐛 Bug fixes
+
+- Fixed `AppShell` component not showing scrollbar when content is taller than the viewport. ([#128](https://github.com/TiendaNube/nimbus-patterns/pull/128) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-30 `1.23.2`
 
 #### 💡 Others

--- a/packages/react/src/components/AppShell/CHANGELOG.md
+++ b/packages/react/src/components/AppShell/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AppShell component is the main outer frame of an application. It provides the basic architecture to build an application inside of our admin.
 
+## 2025-09-30 `1.8.1`
+
+#### 🐛 Bug fixes
+
+- Fixed `AppShell` component not showing scrollbar when content is taller than the viewport. ([#128](https://github.com/TiendaNube/nimbus-patterns/pull/128) by [@joacotornello](https://github.com/joacotornello))
+
 ## 2025-09-27 `1.8.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/AppShell/src/AppShell.tsx
+++ b/packages/react/src/components/AppShell/src/AppShell.tsx
@@ -128,7 +128,6 @@ const AppShell: React.FC<AppShellProps> & AppShellComponents = ({
         flex="1 1 auto"
         height="100vh"
         width="100%"
-        overflow="hidden"
         backgroundColor="neutral-surface"
         // Fully customizable due to client needs
         {...contentProperties}


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AppShell now correctly shows a scrollbar when content exceeds the viewport height, preventing hidden content and restoring expected scrolling. Improves usability on long pages, dashboards, and forms across layouts and themes. No behavior changes for pages that already fit within the viewport.

* **Documentation**
  * Changelogs updated to reflect the fix and new patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->