### PR TITLE
fix: scroll issue on Chat fullsize

### DIFF
--- a/.yarn/versions/94a40660.yml
+++ b/.yarn/versions/94a40660.yml
@@ -1,3 +1,6 @@
 releases:
   "@nimbus-ds/app-shell": patch
   "@nimbus-ds/patterns": patch
+
+declined:
+  - nimbus-patterns

--- a/.yarn/versions/94a40660.yml
+++ b/.yarn/versions/94a40660.yml
@@ -1,0 +1,3 @@
+releases:
+  "@nimbus-ds/app-shell": patch
+  "@nimbus-ds/patterns": patch

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop's team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2026-05-04 `1.33.2`
+
+#### 🐛 Bug fixes
+
+- Fixed page scroll not being locked while `AppShellChat` is expanded in fullscreen mode. ([#167](https://github.com/TiendaNube/nimbus-patterns/pull/167) by [@jffs](https://github.com/jffs))
+
 ## 2026-03-04 `1.33.1`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/components/AppShell/CHANGELOG.md
+++ b/packages/react/src/components/AppShell/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The AppShell component is the main outer frame of an application. It provides the basic architecture to build an application inside of our admin.
 
+## 2026-05-04 `1.9.1`
+
+#### 🐛 Bug fixes
+
+- Fixed page scroll not being locked while `AppShellChat` is expanded in fullscreen mode. ([#167](https://github.com/TiendaNube/nimbus-patterns/pull/167) by [@jffs](https://github.com/jffs))
+
 ## 2026-03-11 `1.9.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/AppShell/src/components/AppShellChat/AppShellChat.tsx
+++ b/packages/react/src/components/AppShell/src/components/AppShellChat/AppShellChat.tsx
@@ -74,6 +74,17 @@ const AppShellChat: React.FC<AppShellChatProps> = ({
     }
   }, [isExpanded]);
 
+  useEffect(() => {
+    if (!isExpanded || typeof document === "undefined") return undefined;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isExpanded]);
+
   const safeParentLeft = Math.max(bounds.parentLeft, 0);
   const safeParentTop = Math.max(bounds.parentTop, 0);
   const expandedWidth = `calc(100% - ${safeParentLeft}px)`;

--- a/packages/react/src/components/AppShell/src/components/AppShellChat/appShellChat.spec.tsx
+++ b/packages/react/src/components/AppShell/src/components/AppShellChat/appShellChat.spec.tsx
@@ -63,6 +63,24 @@ describe("GIVEN <AppShellChat />", () => {
         2
       );
     });
+
+    it("SHOULD lock body scroll while expanded and restore on collapse", () => {
+      document.body.style.overflow = "auto";
+
+      const { rerender } = render(
+        <AppShellChat expanded data-testid="app-shell-chat-element">
+          {bodyChildren}
+        </AppShellChat>
+      );
+      expect(document.body.style.overflow).toBe("hidden");
+
+      rerender(
+        <AppShellChat expanded={false} data-testid="app-shell-chat-element">
+          {bodyChildren}
+        </AppShellChat>
+      );
+      expect(document.body.style.overflow).toBe("auto");
+    });
   });
 
   describe("WHEN defaultExpanded is true", () => {


### PR DESCRIPTION
## Type

- [x] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️
When AppShellChat expands to fullscreen, the underlying page content remained scrollable, causing a broken UX where users could accidentally scroll the background while interacting with the chat.                                                                                                               

This fix locks document.body scroll (overflow: hidden) while the chat is in expanded mode, and restores the previous overflow value when it collapses. A unit test was added to cover both the lock and restore behavior.    


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AppShellChat now prevents page scrolling when expanded and automatically restores scroll behavior when collapsed. Includes safety checks for non-DOM environments.

* **Tests**
  * Added test cases to verify scroll locking behavior during expansion and restoration during collapse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->