### PR TITLE
feat: rework PlanDisplay to Plans 2.0 design

### DIFF
--- a/.yarn/versions/plan-display-plans-2.yml
+++ b/.yarn/versions/plan-display-plans-2.yml
@@ -1,0 +1,5 @@
+releases:
+  "@nimbus-ds/plan-display": minor
+
+declined:
+  - nimbus-patterns

--- a/.yarn/versions/plan-display-plans-2.yml
+++ b/.yarn/versions/plan-display-plans-2.yml
@@ -1,5 +1,6 @@
 releases:
   "@nimbus-ds/plan-display": minor
+  "@nimbus-ds/patterns-webpack": patch
 
 declined:
   - nimbus-patterns

--- a/packages/core/webpack/package.json
+++ b/packages/core/webpack/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "g:webpack": "cd $INIT_CWD && webpack"
+    "g:webpack": "cd \"$INIT_CWD\" && webpack"
   },
   "homepage": "https://nimbus.nuvemshop.com.br/documentation",
   "repository": {

--- a/packages/react/src/components/PlanDisplay/CHANGELOG.md
+++ b/packages/react/src/components/PlanDisplay/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 EmptyApp allows the user to build marketing-style landing pages for apps. It features internal components meant to build hero sections, content sections with images and text with features, and payment plans.
 
+## 2026-06-11 `2.0.0`
+
+### ✨ Features
+
+- Reworked `PlanDisplay` to the Plans 2.0 design as the canonical layout, matching the Figma master component. `PlanDisplay.Card` now renders the default card with a level-2 shadow, plus two opt-in variants: `ribbonLabel` (a "Más escogido" ribbon with a primary 2px border) and `gradient` (primary-surface → background gradient). Added a `tag` slot on `PlanDisplay.Header` (e.g. "Plan actual"), a new `PlanDisplay.Price` subcomponent (current price + optional previous price, period and annual note), a `badge` slot on `PlanDisplay.Bullet` (e.g. "Nuevo"), and an `icon` slot on `PlanDisplay.Footer` for add-on rows. (by [@noecondoleo](https://github.com/noecondoleo))
+
+### ⚠️ Breaking changes
+
+- Removed the legacy `highlighted` prop on `PlanDisplay.Card`. Use `ribbonLabel` for the featured plan or `gradient` for the gradient variant. (by [@noecondoleo](https://github.com/noecondoleo))
+
 ## 2026-01-15 `1.1.1`
 
 #### 📚 3rd party library updates

--- a/packages/react/src/components/PlanDisplay/CHANGELOG.md
+++ b/packages/react/src/components/PlanDisplay/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-EmptyApp allows the user to build marketing-style landing pages for apps. It features internal components meant to build hero sections, content sections with images and text with features, and payment plans.
+PlanDisplay allows the user to present subscription plans and pricing. It features internal components to build plan cards with headers, prices, feature bullets, and footers — including featured-plan and gradient variants.
 
 ## 2026-06-11 `2.0.0`
 

--- a/packages/react/src/components/PlanDisplay/README.md
+++ b/packages/react/src/components/PlanDisplay/README.md
@@ -11,3 +11,57 @@ $ yarn add @nimbus-ds/plan-display
 # or
 $ npm install @nimbus-ds/plan-display
 ```
+
+## Subcomponents
+
+- `PlanDisplay.Card` — wraps a single plan. By default it renders the card with a level-2 shadow.
+  Pass `ribbonLabel` to render the featured ribbon on top (e.g. `"Más escogido"`) with a primary 2px
+  border, or `gradient` for the gradient background variant.
+- `PlanDisplay.Header` — renders the plan `subtitle` and `title`. Pass an optional `tag` slot (e.g. a
+  `<Tag>` like `"Plan actual"`) shown to the right of the subtitle.
+- `PlanDisplay.Price` — renders the `price` and optional `previousPrice` (line-through), `period`
+  (e.g. `"/mes"`) and `annualNote`. Typically passed as the Header `title`.
+- `PlanDisplay.Content` — wraps the plan bullets and supporting content.
+- `PlanDisplay.Bullet` — a feature row with an `icon`, optional `disabled` state and an optional inline
+  `badge` slot (e.g. a `<Tag>` like `"Nuevo"`).
+- `PlanDisplay.Footer` — bottom area. Pass an optional `icon` to render an add-on style row (icon + link).
+- `PlanDisplay.Spacing` — a standalone divider line. Note that `PlanDisplay.Content` already renders
+  this divider at its top to separate the price block from the plan description (as in the Figma master),
+  so you usually don't need to add it manually.
+
+## Plans 2.0 example
+
+```tsx
+import { PlanDisplay } from "@nimbus-ds/plan-display";
+import { Box, Button, Link, Tag, Text } from "@nimbus-ds/components";
+import { CashierIcon, CheckIcon } from "@nimbus-ds/icons";
+
+<PlanDisplay minPlanWidth="236px">
+  <PlanDisplay.Card ribbonLabel="Más escogido">
+    <PlanDisplay.Header
+      subtitle="Avanzado"
+      title={<PlanDisplay.Price price="$999" period="/mes" />}
+    />
+    <PlanDisplay.Content>
+      <Box display="flex" flexDirection="column" gap="3" pb="2">
+        <Text>Gestión avanzada y control total para tu negocio.</Text>
+        <Button appearance="primary" fullWidth>
+          Subir de plan
+        </Button>
+      </Box>
+      <PlanDisplay.Bullet icon={<CheckIcon />} badge={<Tag appearance="primary">Nuevo</Tag>}>
+        Hasta 3 tablas de precios mayoristas
+      </PlanDisplay.Bullet>
+    </PlanDisplay.Content>
+    <PlanDisplay.Footer icon={<CashierIcon />}>
+      <Text>
+        Obtén{" "}
+        <Link as="a" href="#" appearance="primary" textDecoration="underline">
+          Punto de venta Plus
+        </Link>{" "}
+        extra por $149.90/mes
+      </Text>
+    </PlanDisplay.Footer>
+  </PlanDisplay.Card>
+</PlanDisplay>;
+```

--- a/packages/react/src/components/PlanDisplay/src/PlanDisplay.tsx
+++ b/packages/react/src/components/PlanDisplay/src/PlanDisplay.tsx
@@ -24,7 +24,7 @@ const PlanDisplay: React.FC<PlanDisplayProps> & PlanDisplayComponents = ({
     gridTemplateColumns={`repeat(auto-fit, minmax(${minPlanWidth}, 1fr))`}
     gap="6"
     justifyContent="center"
-    alignItems="flex-start"
+    alignItems="stretch"
     {...rest}
   >
     {children}

--- a/packages/react/src/components/PlanDisplay/src/PlanDisplay.tsx
+++ b/packages/react/src/components/PlanDisplay/src/PlanDisplay.tsx
@@ -10,6 +10,7 @@ import {
   PlanDisplayCardContent,
   PlanDisplayCardFooter,
   PlanDisplayCardHeader,
+  PlanDisplayCardPrice,
   PlanDisplayCardSpacing,
 } from "./components";
 
@@ -32,6 +33,7 @@ const PlanDisplay: React.FC<PlanDisplayProps> & PlanDisplayComponents = ({
 
 PlanDisplay.Card = PlanDisplayCard;
 PlanDisplay.Header = PlanDisplayCardHeader;
+PlanDisplay.Price = PlanDisplayCardPrice;
 PlanDisplay.Content = PlanDisplayCardContent;
 PlanDisplay.Spacing = PlanDisplayCardSpacing;
 PlanDisplay.Bullet = PlanDisplayBullet;
@@ -41,6 +43,7 @@ PlanDisplay.displayName = "PlanDisplay";
 PlanDisplay.Card.displayName = "PlanDisplay.Card";
 PlanDisplay.Bullet.displayName = "PlanDisplay.Bullet";
 PlanDisplay.Header.displayName = "PlanDisplay.CardHeader";
+PlanDisplay.Price.displayName = "PlanDisplay.Price";
 PlanDisplay.Content.displayName = "PlanDisplay.CardContent";
 PlanDisplay.Spacing.displayName = "PlanDisplay.CardSpacing";
 

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
@@ -5,25 +5,43 @@ import { PlanDisplayBulletProps } from "./planDisplayBullet.types";
 const PlanDisplayBullet: React.FC<PlanDisplayBulletProps> = ({
   icon,
   disabled,
+  badge,
   children,
 }) => (
-  <Box display="flex" gap="2">
+  <Box display="flex" gap="2" alignItems="flex-start">
     <Box display="flex" alignItems="center">
       <Text
         as="span"
-        color={disabled ? "neutral-interactive" : "success-interactive"}
+        color={disabled ? "neutral-interactive" : "primary-interactive"}
       >
         <Box display="flex" alignItems="center">
           {icon}
         </Box>
       </Text>
     </Box>
-    <Text
-      fontWeight="medium"
-      color={disabled ? "neutral-interactive" : "neutral-textLow"}
-    >
-      {children}
-    </Text>
+    {badge ? (
+      <Text
+        fontWeight="regular"
+        color={disabled ? "neutral-interactive" : "neutral-textLow"}
+      >
+        {children}{" "}
+        <Box
+          as="span"
+          display="inline-flex"
+          gap="2"
+          style={{ verticalAlign: "middle" }}
+        >
+          {badge}
+        </Box>
+      </Text>
+    ) : (
+      <Text
+        fontWeight="regular"
+        color={disabled ? "neutral-interactive" : "neutral-textLow"}
+      >
+        {children}
+      </Text>
+    )}
   </Box>
 );
 

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
@@ -25,14 +25,16 @@ const PlanDisplayBullet: React.FC<PlanDisplayBulletProps> = ({
         color={disabled ? "neutral-interactive" : "neutral-textLow"}
       >
         {children}{" "}
-        <Box
-          as="span"
-          display="inline-flex"
-          gap="2"
-          style={{ verticalAlign: "middle" }}
+        {/* Native span: Box drops `style`, so `vertical-align` would never apply on a Box. */}
+        <span
+          style={{
+            display: "inline-flex",
+            gap: "var(--nimbus-spacing-2)",
+            verticalAlign: "middle",
+          }}
         >
           {badge}
-        </Box>
+        </span>
       </Text>
     ) : (
       <Text

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/PlanDisplayBullet.tsx
@@ -8,7 +8,7 @@ const PlanDisplayBullet: React.FC<PlanDisplayBulletProps> = ({
   badge,
   children,
 }) => (
-  <Box display="flex" gap="2" alignItems="flex-start">
+  <Box display="flex" gap="2" alignItems="center">
     <Box display="flex" alignItems="center">
       <Text
         as="span"

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/planDisplayBullet.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/planDisplayBullet.types.ts
@@ -3,6 +3,11 @@ import { PropsWithChildren, ReactNode } from "react";
 export type PlanDisplayBulletProperties = {
   icon: ReactNode;
   disabled?: boolean;
+  /**
+   * Optional slot rendered inline after the bullet text (e.g. a `<Tag>` like "Nuevo").
+   * @TJS-type React.ReactNode
+   */
+  badge?: ReactNode;
 };
 export type PlanDisplayBulletProps =
   PropsWithChildren<PlanDisplayBulletProperties>;

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/planDisplayCardBullet.spec.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayBullet/planDisplayCardBullet.spec.tsx
@@ -33,5 +33,16 @@ describe("GIVEN <PlanDisplayBullet />", () => {
       expect(screen.getByText("Plan display bullet")).toBeDefined();
       expect(screen.getByTestId("icon-id")).toBeDefined();
     });
+
+    it("SHOULD render the badge slot when provided", () => {
+      makeSut({
+        icon,
+        children: "Plan display bullet",
+        badge: <span data-testid="badge-id">Nuevo</span>,
+      });
+
+      expect(screen.getByText("Plan display bullet")).toBeDefined();
+      expect(screen.getByTestId("badge-id")).toBeDefined();
+    });
   });
 });

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
@@ -45,7 +45,6 @@ const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
         flex="1 1 auto"
         display="flex"
         flexDirection="column"
-        padding="4"
         backgroundColor="neutral-background"
         borderRadius="2"
         overflow="hidden"
@@ -56,12 +55,23 @@ const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
               borderWidth: "2",
             }
           : { boxShadow: "2" })}
-        style={{
-          background: gradient && !hasRibbon ? GRADIENT_BACKGROUND : undefined,
-          ...style,
-        }}
       >
-        {children}
+        {/* Content lives in a native element because @nimbus-ds/components Box drops the
+            `style` prop (it renders only sprinkle-generated styles). Routing the gradient
+            background and any consumer `style` through here is the only way they take effect.
+            The div fills the card as a flex column so footers still anchor with `margin-top: auto`. */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            flex: "1 1 auto",
+            padding: "var(--nimbus-spacing-4)",
+            background: gradient && !hasRibbon ? GRADIENT_BACKGROUND : undefined,
+            ...style,
+          }}
+        >
+          {children}
+        </div>
       </Box>
     </Box>
   );

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
@@ -12,54 +12,57 @@ const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
   style,
   ...rest
 }) => {
-  if (ribbonLabel) {
-    return (
-      <Box {...rest} style={style} display="flex" flexDirection="column">
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-            backgroundColor: "var(--nimbus-colors-primary-interactive)",
-            paddingTop: "var(--nimbus-spacing-0-5)",
-            paddingBottom: "var(--nimbus-spacing-2)",
-            borderTopLeftRadius: "var(--nimbus-shape-border-radius-2)",
-            borderTopRightRadius: "var(--nimbus-shape-border-radius-2)",
-            marginBottom: "calc(var(--nimbus-spacing-2) * -1)",
-          }}
-        >
-          <Text fontWeight="medium" color="neutral-background" textAlign="center">
-            {ribbonLabel}
-          </Text>
-        </div>
-        <Box
-          backgroundColor="neutral-background"
-          borderColor="primary-interactive"
-          borderRadius="2"
-          borderStyle="solid"
-          borderWidth="2"
-          overflow="hidden"
-          padding="4"
-        >
-          {children}
-        </Box>
-      </Box>
-    );
-  }
+  const hasRibbon = Boolean(ribbonLabel);
 
   return (
-    <Box {...rest} borderRadius="2" boxShadow="2" overflow="hidden">
+    <Box {...rest} display="flex" flexDirection="column" height="100%">
+      {/* Ribbon area: visible when `ribbonLabel` is set, an invisible placeholder of the
+          same height otherwise. Rendering it on every card reserves identical top space so
+          the content rows (subtitle, price, bullets) align across the grid. */}
       <div
+        aria-hidden={hasRibbon ? undefined : true}
         style={{
-          padding: "var(--nimbus-spacing-4)",
-          background: gradient
-            ? GRADIENT_BACKGROUND
-            : "var(--nimbus-colors-neutral-background)",
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: hasRibbon
+            ? "var(--nimbus-colors-primary-interactive)"
+            : "transparent",
+          paddingTop: "var(--nimbus-spacing-0-5)",
+          paddingBottom: "var(--nimbus-spacing-2)",
+          borderTopLeftRadius: "var(--nimbus-shape-border-radius-2)",
+          borderTopRightRadius: "var(--nimbus-shape-border-radius-2)",
+          marginBottom: "calc(var(--nimbus-spacing-2) * -1)",
+        }}
+      >
+        <Text fontWeight="medium" color="neutral-background" textAlign="center">
+          {ribbonLabel || " "}
+        </Text>
+      </div>
+      {/* Content grows to fill the card height (cards in a row stretch to match), so footers
+          anchored with `margin-top: auto` line up at the bottom. */}
+      <Box
+        flex="1 1 auto"
+        display="flex"
+        flexDirection="column"
+        padding="4"
+        backgroundColor="neutral-background"
+        borderRadius="2"
+        overflow="hidden"
+        {...(hasRibbon
+          ? {
+              borderColor: "primary-interactive",
+              borderStyle: "solid",
+              borderWidth: "2",
+            }
+          : { boxShadow: "2" })}
+        style={{
+          background: gradient && !hasRibbon ? GRADIENT_BACKGROUND : undefined,
           ...style,
         }}
       >
         {children}
-      </div>
+      </Box>
     </Box>
   );
 };

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/PlanDisplayCard.tsx
@@ -1,23 +1,65 @@
 import React from "react";
-import { Box, BoxProps, Card } from "@nimbus-ds/components";
+import { Box, Text } from "@nimbus-ds/components";
 import { PlanDisplayCardProps } from "./planDisplayCard.types";
 
+const GRADIENT_BACKGROUND =
+  "linear-gradient(194.55deg, var(--nimbus-colors-primary-surface) 4.18%, var(--nimbus-colors-neutral-background) 45.97%)";
+
 const PlanDisplayCard: React.FC<PlanDisplayCardProps> = ({
-  highlighted,
+  ribbonLabel,
+  gradient,
   children,
+  style,
   ...rest
 }) => {
-  const highlightedProps: BoxProps = {
-    borderColor: "primary-interactive",
-    borderRadius: "2",
-    borderStyle: "solid",
-    borderWidth: "3",
-    boxShadow: "3",
-  };
+  if (ribbonLabel) {
+    return (
+      <Box {...rest} style={style} display="flex" flexDirection="column">
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            backgroundColor: "var(--nimbus-colors-primary-interactive)",
+            paddingTop: "var(--nimbus-spacing-0-5)",
+            paddingBottom: "var(--nimbus-spacing-2)",
+            borderTopLeftRadius: "var(--nimbus-shape-border-radius-2)",
+            borderTopRightRadius: "var(--nimbus-shape-border-radius-2)",
+            marginBottom: "calc(var(--nimbus-spacing-2) * -1)",
+          }}
+        >
+          <Text fontWeight="medium" color="neutral-background" textAlign="center">
+            {ribbonLabel}
+          </Text>
+        </div>
+        <Box
+          backgroundColor="neutral-background"
+          borderColor="primary-interactive"
+          borderRadius="2"
+          borderStyle="solid"
+          borderWidth="2"
+          overflow="hidden"
+          padding="4"
+        >
+          {children}
+        </Box>
+      </Box>
+    );
+  }
 
   return (
-    <Box {...(highlighted ? highlightedProps : {})} {...rest}>
-      <Card>{children}</Card>
+    <Box {...rest} borderRadius="2" boxShadow="2" overflow="hidden">
+      <div
+        style={{
+          padding: "var(--nimbus-spacing-4)",
+          background: gradient
+            ? GRADIENT_BACKGROUND
+            : "var(--nimbus-colors-neutral-background)",
+          ...style,
+        }}
+      >
+        {children}
+      </div>
     </Box>
   );
 };

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.spec.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.spec.tsx
@@ -18,9 +18,16 @@ describe("GIVEN <PlanDisplayCard />", () => {
       expect(screen.getByText("Body content")).toBeDefined();
     });
 
-    it("SHOULD render highlighted state correctly", () => {
-      makeSut({ highlighted: true });
+    it("SHOULD render the gradient variant correctly", () => {
+      makeSut({ gradient: true });
 
+      expect(screen.getByText("Body content")).toBeDefined();
+    });
+
+    it("SHOULD render the ribbon label when provided", () => {
+      makeSut({ ribbonLabel: "Más escogido" });
+
+      expect(screen.getByText("Más escogido")).toBeDefined();
       expect(screen.getByText("Body content")).toBeDefined();
     });
   });

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCard/planDisplayCard.types.ts
@@ -1,8 +1,19 @@
 import { BoxProps } from "@nimbus-ds/components";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
 export interface PlanDisplayCardProperties {
-  highlighted?: boolean;
+  /**
+   * Renders the card with the Plans 2.0 gradient background (primary-surface → neutral-background).
+   * Ignored when `ribbonLabel` is provided.
+   */
+  gradient?: boolean;
+  /**
+   * Label shown in a ribbon on top of the card (e.g. "Más escogido"). When provided, the card
+   * is rendered with the featured style (primary ribbon + 2px primary border, no shadow),
+   * taking precedence over `gradient`.
+   * @TJS-type React.ReactNode
+   */
+  ribbonLabel?: ReactNode;
 }
 export type PlanDisplayCardProps =
   PropsWithChildren<PlanDisplayCardProperties> &

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
@@ -9,7 +9,7 @@ const PlanDisplayCardContent: React.FC<PlanDisplayCardContentProperties> = ({
   <Card.Body>
     <PlanDisplayCardSpacing />
 
-    <Box display="flex" flexDirection="column" gap="1" py="4">
+    <Box display="flex" flexDirection="column" gap="1" pb="4">
       {children}
     </Box>
   </Card.Body>

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
@@ -9,7 +9,7 @@ const PlanDisplayCardContent: React.FC<PlanDisplayCardContentProperties> = ({
   <Card.Body>
     <PlanDisplayCardSpacing />
 
-    <Box display="flex" flexDirection="column" gap="3" pb="4">
+    <Box display="flex" flexDirection="column" gap="3">
       {children}
     </Box>
   </Card.Body>

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardContent/PlanDisplayCardContent.tsx
@@ -9,7 +9,7 @@ const PlanDisplayCardContent: React.FC<PlanDisplayCardContentProperties> = ({
   <Card.Body>
     <PlanDisplayCardSpacing />
 
-    <Box display="flex" flexDirection="column" gap="1" pb="4">
+    <Box display="flex" flexDirection="column" gap="3" pb="4">
       {children}
     </Box>
   </Card.Body>

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
@@ -1,15 +1,26 @@
 import React from "react";
-import { Box } from "@nimbus-ds/components";
+import { Box, Divider } from "@nimbus-ds/components";
 import { PlanDisplayCardFooterProperties } from "./planDisplayCardFooter.types";
-import PlanDisplayCardSpacing from "../PlanDisplayCardSpacing";
 
 const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
+  icon,
   children,
 }) => (
-  <Box display="flex" flexDirection="column" gap="4">
-    <PlanDisplayCardSpacing />
+  <Box display="flex" flexDirection="column">
+    <Box mb="3">
+      <Divider />
+    </Box>
 
-    <Box>{children}</Box>
+    {icon ? (
+      <Box display="flex" gap="2" alignItems="flex-start">
+        <Box display="flex" alignItems="center">
+          {icon}
+        </Box>
+        <Box>{children}</Box>
+      </Box>
+    ) : (
+      <Box>{children}</Box>
+    )}
   </Box>
 );
 

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
@@ -6,7 +6,9 @@ const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
   icon,
   children,
 }) => (
-  <Box display="flex" flexDirection="column">
+  // `marginTop: auto` pins the footer to the bottom of the (full-height, flex-column) card
+  // so footers stay aligned across cards in the same row.
+  <Box display="flex" flexDirection="column" style={{ marginTop: "auto" }}>
     <Box mb="3">
       <Divider />
     </Box>

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
@@ -7,8 +7,9 @@ const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
   children,
 }) => (
   // `marginTop: auto` pins the footer to the bottom of the (full-height, flex-column) card
-  // so footers stay aligned across cards in the same row.
-  <Box display="flex" flexDirection="column" style={{ marginTop: "auto" }}>
+  // so footers stay aligned across cards in the same row. Native element on purpose: Box
+  // discards `style`, so the `margin-top: auto` would be a no-op on a Box.
+  <div style={{ display: "flex", flexDirection: "column", marginTop: "auto" }}>
     <Box mt="3" mb="3">
       <Divider />
     </Box>
@@ -25,7 +26,7 @@ const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
     ) : (
       <Box>{children}</Box>
     )}
-  </Box>
+  </div>
 );
 
 export { PlanDisplayCardFooter };

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
@@ -9,7 +9,7 @@ const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
   // `marginTop: auto` pins the footer to the bottom of the (full-height, flex-column) card
   // so footers stay aligned across cards in the same row.
   <Box display="flex" flexDirection="column" style={{ marginTop: "auto" }}>
-    <Box mb="3">
+    <Box mt="3" mb="3">
       <Divider />
     </Box>
 

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/PlanDisplayCardFooter.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box, Divider } from "@nimbus-ds/components";
+import { Box, Divider, Text } from "@nimbus-ds/components";
 import { PlanDisplayCardFooterProperties } from "./planDisplayCardFooter.types";
 
 const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
@@ -15,9 +15,11 @@ const PlanDisplayCardFooter: React.FC<PlanDisplayCardFooterProperties> = ({
 
     {icon ? (
       <Box display="flex" gap="2" alignItems="flex-start">
-        <Box display="flex" alignItems="center">
-          {icon}
-        </Box>
+        <Text as="span" color="primary-interactive">
+          <Box display="flex" alignItems="center">
+            {icon}
+          </Box>
+        </Text>
         <Box>{children}</Box>
       </Box>
     ) : (

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/planDisplayCardFooter.spec.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/planDisplayCardFooter.spec.tsx
@@ -18,5 +18,12 @@ describe("GIVEN <PlanDisplayCardFooter />", () => {
       makeSut({});
       expect(screen.getByText("Body content")).toBeDefined();
     });
+
+    it("SHOULD render the add-on icon and children when icon is provided", () => {
+      makeSut({ icon: <span data-testid="addon-icon">icon</span> });
+
+      expect(screen.getByTestId("addon-icon")).toBeDefined();
+      expect(screen.getByText("Body content")).toBeDefined();
+    });
   });
 });

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/planDisplayCardFooter.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardFooter/planDisplayCardFooter.types.ts
@@ -1,3 +1,10 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, ReactNode } from "react";
 
-export type PlanDisplayCardFooterProperties = PropsWithChildren;
+export type PlanDisplayCardFooterProperties = PropsWithChildren<{
+  /**
+   * Optional leading icon for an add-on style footer row (e.g. a point-of-sale icon next to a link).
+   * When provided, the footer renders the icon and children side by side.
+   * @TJS-type React.ReactNode
+   */
+  icon?: ReactNode;
+}>;

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/PlanDisplayCardHeader.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/PlanDisplayCardHeader.tsx
@@ -16,7 +16,7 @@ const PlanDisplayCardHeader: React.FC<PlanDisplayCardHeaderProps> = ({
         alignItems="center"
         gap="2"
       >
-        <Text fontWeight="bold" fontSize="highlight">
+        <Text fontWeight="bold" fontSize="highlight" color="neutral-textHigh">
           {subtitle}
         </Text>
         {tag}

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/PlanDisplayCardHeader.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/PlanDisplayCardHeader.tsx
@@ -5,19 +5,30 @@ import { PlanDisplayCardHeaderProps } from "./planDisplayCardHeader.types";
 const PlanDisplayCardHeader: React.FC<PlanDisplayCardHeaderProps> = ({
   subtitle,
   title,
+  tag,
   children,
 }) => (
-  <Box display="flex" flexDirection="column">
-    <Text fontWeight="bold" fontSize="highlight">
-      {subtitle}
-    </Text>
+  <Box display="flex" flexDirection="column" gap="3">
+    {tag ? (
+      <Box
+        display="flex"
+        justifyContent="space-between"
+        alignItems="center"
+        gap="2"
+      >
+        <Text fontWeight="bold" fontSize="highlight">
+          {subtitle}
+        </Text>
+        {tag}
+      </Box>
+    ) : (
+      <Text fontWeight="bold" fontSize="highlight" color="neutral-textHigh">
+        {subtitle}
+      </Text>
+    )}
     {title}
 
-    {children && (
-      <Box pt="3" pb="4">
-        {children}
-      </Box>
-    )}
+    {children && <Box pb="4">{children}</Box>}
   </Box>
 );
 

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/planDisplayCardHeader.spec.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/planDisplayCardHeader.spec.tsx
@@ -25,5 +25,16 @@ describe("GIVEN <PlanDisplayCardHeader />", () => {
       expect(screen.getByText("Subtitle")).toBeDefined();
       expect(screen.getByText("Title")).toBeDefined();
     });
+
+    it("SHOULD render the tag slot when provided", () => {
+      makeSut({
+        subtitle: "Subtitle",
+        title: <Text>Title</Text>,
+        tag: <span>Plan actual</span>,
+      });
+
+      expect(screen.getByText("Plan actual")).toBeDefined();
+      expect(screen.getByText("Subtitle")).toBeDefined();
+    });
   });
 });

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/planDisplayCardHeader.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardHeader/planDisplayCardHeader.types.ts
@@ -3,6 +3,12 @@ import { PropsWithChildren, ReactNode } from "react";
 export type PlanDisplayCardHeaderProperties = {
   subtitle: string;
   title: ReactNode;
+  /**
+   * Optional slot rendered to the right of the subtitle (e.g. a `<Tag>` like "Plan actual").
+   * When provided, the subtitle row is laid out with space between the subtitle and the tag.
+   * @TJS-type React.ReactNode
+   */
+  tag?: ReactNode;
 };
 export type PlanDisplayCardHeaderProps =
   PropsWithChildren<PlanDisplayCardHeaderProperties>;

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/PlanDisplayCardPrice.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/PlanDisplayCardPrice.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Box, Text, Title } from "@nimbus-ds/components";
+import { PlanDisplayCardPriceProps } from "./planDisplayCardPrice.types";
+
+const PlanDisplayCardPrice: React.FC<PlanDisplayCardPriceProps> = ({
+  price,
+  previousPrice,
+  period,
+  annualNote,
+}) => (
+  <Box display="flex" flexDirection="column" gap="2">
+    <Box display="flex" alignItems="center" gap="0-5">
+      <Title as="h3" color="neutral-textHigh">
+        {price}
+      </Title>
+      {previousPrice && (
+        <Text as="span" fontSize="base">
+          {/* `neutral-interactivePressed` is not exposed by Text's `color` prop,
+              so the token is applied via its CSS variable. */}
+          <span
+            style={{
+              color: "var(--nimbus-colors-neutral-interactivePressed)",
+              textDecoration: "line-through",
+            }}
+          >
+            {previousPrice}
+          </span>
+        </Text>
+      )}
+      {period && (
+        <Text as="span" color="neutral-textHigh">
+          {period}
+        </Text>
+      )}
+    </Box>
+    {annualNote && (
+      <Text as="p" fontSize="caption" color="neutral-textLow">
+        {annualNote}
+      </Text>
+    )}
+  </Box>
+);
+
+export { PlanDisplayCardPrice };

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/index.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/index.ts
@@ -1,0 +1,5 @@
+import { PlanDisplayCardPrice } from "./PlanDisplayCardPrice";
+
+export { PlanDisplayCardPrice };
+
+export default PlanDisplayCardPrice;

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.spec.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.spec.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { PlanDisplayCardPrice } from "./PlanDisplayCardPrice";
+import { PlanDisplayCardPriceProps } from "./planDisplayCardPrice.types";
+
+const makeSut = (rest: PlanDisplayCardPriceProps) => {
+  render(<PlanDisplayCardPrice {...rest} />);
+};
+
+describe("GIVEN <PlanDisplayCardPrice />", () => {
+  describe("WHEN rendered", () => {
+    it("SHOULD render the price correctly", () => {
+      makeSut({ price: "$999" });
+
+      expect(screen.getByText("$999")).toBeDefined();
+    });
+
+    it("SHOULD render previousPrice, period and annualNote when provided", () => {
+      makeSut({
+        price: "$24.999",
+        previousPrice: "$29.999",
+        period: "/mes",
+        annualNote: "$269.990/año",
+      });
+
+      expect(screen.getByText("$24.999")).toBeDefined();
+      expect(screen.getByText("$29.999")).toBeDefined();
+      expect(screen.getByText("/mes")).toBeDefined();
+      expect(screen.getByText("$269.990/año")).toBeDefined();
+    });
+  });
+});

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.stories.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Text } from "@nimbus-ds/components";
+import { PlanDisplay } from "../../PlanDisplay";
+
+const meta: Meta<typeof PlanDisplay.Price> = {
+  title: "Patterns/PlanDisplay/PlanDisplay.Price",
+  component: PlanDisplay.Price,
+  argTypes: {
+    annualNote: {
+      control: { disable: true },
+    },
+  },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof PlanDisplay.Price>;
+
+export const base: Story = {
+  args: {
+    price: "$999",
+    period: "/mes",
+  },
+};
+
+export const withPreviousPrice: Story = {
+  args: {
+    price: "$24.999",
+    previousPrice: "$29.999",
+    period: "/mes",
+  },
+};
+
+export const withAnnualNote: Story = {
+  args: {
+    price: "$24.999",
+    previousPrice: "$29.999",
+    period: "/mes",
+    annualNote: (
+      <>
+        $269.990/año.{" "}
+        <Text as="span" color="primary-textLow" fontSize="caption">
+          Ahorra $30.000.
+        </Text>
+      </>
+    ),
+  },
+};

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardPrice/planDisplayCardPrice.types.ts
@@ -1,0 +1,27 @@
+import { ReactNode } from "react";
+
+export type PlanDisplayCardPriceProperties = {
+  /**
+   * The current price of the plan (e.g. "$999"). Rendered as the main, prominent value.
+   * @TJS-type React.ReactNode
+   */
+  price: ReactNode;
+  /**
+   * Optional previous price, rendered with a line-through next to the current price.
+   * @TJS-type React.ReactNode
+   */
+  previousPrice?: ReactNode;
+  /**
+   * Optional billing period suffix (e.g. "/mes") rendered next to the price.
+   * @TJS-type React.ReactNode
+   */
+  period?: ReactNode;
+  /**
+   * Optional annual note rendered below the price (e.g. "R$696/año. Economiza R$132.").
+   * Accepts a ReactNode so it can mix colors (e.g. an emphasized savings span).
+   * @TJS-type React.ReactNode
+   */
+  annualNote?: ReactNode;
+};
+
+export type PlanDisplayCardPriceProps = PlanDisplayCardPriceProperties;

--- a/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardSpacing/PlanDisplayCardSpacing.tsx
+++ b/packages/react/src/components/PlanDisplay/src/components/PlanDisplayCardSpacing/PlanDisplayCardSpacing.tsx
@@ -1,17 +1,13 @@
 import React from "react";
-import { Box } from "@nimbus-ds/components";
+import { Box, Divider } from "@nimbus-ds/components";
 import { PlanDisplayCardSpacingProps } from "./planDisplayCardSpacing.types";
 
 const PlanDisplayCardSpacing: React.FC<PlanDisplayCardSpacingProps> = (
   props
 ) => (
-  <Box
-    {...props}
-    borderTopWidth="1"
-    borderColor="neutral-surface"
-    borderStyle="solid"
-    my="1"
-  />
+  <Box {...props} my="3">
+    <Divider />
+  </Box>
 );
 
 export { PlanDisplayCardSpacing };

--- a/packages/react/src/components/PlanDisplay/src/components/index.ts
+++ b/packages/react/src/components/PlanDisplay/src/components/index.ts
@@ -4,3 +4,4 @@ export * from "./PlanDisplayCardContent";
 export * from "./PlanDisplayCardFooter";
 export * from "./PlanDisplayCardSpacing";
 export * from "./PlanDisplayBullet";
+export * from "./PlanDisplayCardPrice";

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
@@ -168,14 +168,6 @@ export const TwoPlans: Story = {
               price="$24.999"
               previousPrice="$29.999"
               period="/mes"
-              annualNote={
-                <>
-                  $269.990/año.{" "}
-                  <Text as="span" color="primary-textLow" fontSize="caption">
-                    Ahorra $30.000.
-                  </Text>
-                </>
-              }
             />
           }
         />
@@ -263,14 +255,6 @@ export const ThreePlans: Story = {
               price="$24.999"
               previousPrice="$29.999"
               period="/mes"
-              annualNote={
-                <>
-                  $269.990/año.{" "}
-                  <Text as="span" color="primary-textLow" fontSize="caption">
-                    Ahorra $30.000.
-                  </Text>
-                </>
-              }
             />
           }
         />

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
@@ -152,7 +152,272 @@ export const Default: Story = {
   ),
 };
 
+/**
+ * Two-plan layout: a current plan (with tag) and a featured upgrade (with ribbon).
+ */
+export const TwoPlans: Story = {
+  render: () => (
+    <PlanDisplay minPlanWidth="236px">
+      {/* Card with tag */}
+      <PlanDisplay.Card>
+        <PlanDisplay.Header
+          subtitle="Esencial"
+          tag={<Tag appearance="neutral">Plan actual</Tag>}
+          title={
+            <PlanDisplay.Price
+              price="$24.999"
+              previousPrice="$29.999"
+              period="/mes"
+              annualNote={
+                <>
+                  $269.990/año.{" "}
+                  <Text as="span" color="primary-textLow" fontSize="caption">
+                    Ahorra $30.000.
+                  </Text>
+                </>
+              }
+            />
+          }
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Potenciá tu marca y vendé como una tienda profesional.</Text>
+            <Button fullWidth>Subir de plan</Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Carga masiva de productos
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Dominio propio
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+      </PlanDisplay.Card>
+
+      {/* Featured card with ribbon */}
+      <PlanDisplay.Card ribbonLabel="Más escogido">
+        <PlanDisplay.Header
+          subtitle="Avanzado"
+          title={<PlanDisplay.Price price="$219.999" period="/mes" />}
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Gestión avanzada y control total para tu negocio.</Text>
+            <Button appearance="primary" fullWidth>
+              Subir de plan
+            </Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Campos personalizados en productos y órdenes
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
+            IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+      </PlanDisplay.Card>
+    </PlanDisplay>
+  ),
+};
+
+/**
+ * Three-plan layout: starter, current plan (with tag) and a featured upgrade (with ribbon).
+ */
+export const ThreePlans: Story = {
+  render: () => (
+    <PlanDisplay minPlanWidth="236px">
+      {/* Default card */}
+      <PlanDisplay.Card>
+        <PlanDisplay.Header
+          subtitle="Inicial"
+          title={<PlanDisplay.Price price="Gratis" />}
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Todo lo que necesitas para empezar a vender online.</Text>
+            <Button fullWidth>Comenzar gratis</Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Tu tienda lista para empezar a vender
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Productos y visitas sin límite
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Medios de pago y envío de Tiendanube
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+      </PlanDisplay.Card>
+
+      {/* Card with tag */}
+      <PlanDisplay.Card>
+        <PlanDisplay.Header
+          subtitle="Esencial"
+          tag={<Tag appearance="neutral">Plan actual</Tag>}
+          title={
+            <PlanDisplay.Price
+              price="$24.999"
+              previousPrice="$29.999"
+              period="/mes"
+              annualNote={
+                <>
+                  $269.990/año.{" "}
+                  <Text as="span" color="primary-textLow" fontSize="caption">
+                    Ahorra $30.000.
+                  </Text>
+                </>
+              }
+            />
+          }
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Potenciá tu marca y vendé como una tienda profesional.</Text>
+            <Button fullWidth>Subir de plan</Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Carga masiva de productos
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Dominio propio
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+      </PlanDisplay.Card>
+
+      {/* Featured card with ribbon */}
+      <PlanDisplay.Card ribbonLabel="Más escogido">
+        <PlanDisplay.Header
+          subtitle="Avanzado"
+          title={<PlanDisplay.Price price="$219.999" period="/mes" />}
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Gestión avanzada y control total para tu negocio.</Text>
+            <Button appearance="primary" fullWidth>
+              Subir de plan
+            </Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Campos personalizados en productos y órdenes
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
+            IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+      </PlanDisplay.Card>
+    </PlanDisplay>
+  ),
+};
+
+/**
+ * Horizontal (desktop) layout: plan info on the left — name, price, description and CTA — separated
+ * by a vertical divider from a single column of feature bullets, vertically centered.
+ */
+export const Horizontal: Story = {
+  render: () => (
+    <Box style={{ maxWidth: 740 }}>
+      <PlanDisplay.Card>
+        <Box display="flex" gap="6" alignItems="center">
+          {/* Plan info */}
+          <Box
+            display="flex"
+            flexDirection="column"
+            gap="3"
+            justifyContent="center"
+            style={{ flex: "0 0 253px" }}
+          >
+            <PlanDisplay.Header
+              subtitle="Inicial"
+              title={<PlanDisplay.Price price="Gratis" />}
+            />
+            <Box display="flex" flexDirection="column" gap="3">
+              <Text>Tudo o que você precisa para começar a vender online.</Text>
+              <Button fullWidth>Bajar de plan</Button>
+            </Box>
+          </Box>
+
+          {/* Vertical divider */}
+          <Box
+            alignSelf="stretch"
+            backgroundColor="neutral-surfaceHighlight"
+            style={{ width: "1px", flexShrink: 0 }}
+          />
+
+          {/* Feature bullets */}
+          <Box
+            display="flex"
+            flexDirection="column"
+            gap="3"
+            style={{ flex: "1 1 0" }}
+          >
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Sua loja autogerenciável e pronta para vender
+            </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Produtos e visitas sem limite
+            </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Meios de pagamento e envio da Nuvemshop
+            </PlanDisplay.Bullet>
+          </Box>
+        </Box>
+      </PlanDisplay.Card>
+    </Box>
+  ),
+};
+
+/**
+ * Mobile layout of the same plan: the horizontal card stacks vertically. The header, description + CTA
+ * and feature bullets are separated by spacing only, matching the horizontal desktop layout.
+ */
+export const HorizontalMobile: Story = {
+  render: () => (
+    <Box style={{ maxWidth: 361 }}>
+      <PlanDisplay.Card>
+        <Box display="flex" flexDirection="column" gap="6">
+          {/* Plan info */}
+          <Box display="flex" flexDirection="column" gap="3">
+            <PlanDisplay.Header
+              subtitle="Inicial"
+              title={<PlanDisplay.Price price="Gratis" />}
+            />
+            <Box display="flex" flexDirection="column" gap="3">
+              <Text>Tudo o que você precisa para começar a vender online.</Text>
+              <Button fullWidth>Bajar de plan</Button>
+            </Box>
+          </Box>
+
+          {/* Feature bullets */}
+          <Box display="flex" flexDirection="column" gap="3">
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Sua loja autogerenciável e pronta para vender
+            </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Produtos e visitas sem limite
+            </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CheckIcon />}>
+              Meios de pagamento e envio da Nuvemshop
+            </PlanDisplay.Bullet>
+          </Box>
+        </Box>
+      </PlanDisplay.Card>
+    </Box>
+  ),
+};
+
 type PlaygroundArgs = {
+  showRibbon: boolean;
+  showGradient: boolean;
   showTag: boolean;
   showDiscount: boolean;
   showSuffix: boolean;
@@ -167,6 +432,8 @@ type PlaygroundArgs = {
  */
 export const Playground: StoryObj<PlaygroundArgs> = {
   args: {
+    showRibbon: true,
+    showGradient: false,
     showTag: true,
     showDiscount: true,
     showSuffix: true,
@@ -175,6 +442,8 @@ export const Playground: StoryObj<PlaygroundArgs> = {
     showFooter: true,
   },
   argTypes: {
+    showRibbon: { control: "boolean" },
+    showGradient: { control: "boolean" },
     showTag: { control: "boolean" },
     showDiscount: { control: "boolean" },
     showSuffix: { control: "boolean" },
@@ -183,6 +452,8 @@ export const Playground: StoryObj<PlaygroundArgs> = {
     showFooter: { control: "boolean" },
   },
   render: ({
+    showRibbon,
+    showGradient,
     showTag,
     showDiscount,
     showSuffix,
@@ -191,7 +462,10 @@ export const Playground: StoryObj<PlaygroundArgs> = {
     showFooter,
   }) => (
     <PlanDisplay minPlanWidth="236px">
-      <PlanDisplay.Card ribbonLabel="Más escogido">
+      <PlanDisplay.Card
+        ribbonLabel={showRibbon ? "Más escogido" : undefined}
+        gradient={showGradient}
+      >
         <PlanDisplay.Header
           subtitle="Avanzado"
           tag={showTag ? <Tag appearance="neutral">Plan actual</Tag> : undefined}

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { Box, Button, Text, Title } from "@nimbus-ds/components";
-import { CheckIcon, CloseIcon } from "@nimbus-ds/icons";
+import { Box, Button, Link, Tag, Text } from "@nimbus-ds/components";
+import { CashierIcon, CheckIcon, GenerativeStarsIcon } from "@nimbus-ds/icons";
 import { PlanDisplay } from "./PlanDisplay";
 
 const meta: Meta<typeof PlanDisplay> = {
@@ -17,345 +17,240 @@ const meta: Meta<typeof PlanDisplay> = {
 export default meta;
 type Story = StoryObj<typeof PlanDisplay>;
 
-export const twoPlans: Story = {
+export const Default: Story = {
   render: () => (
-    <PlanDisplay>
+    <PlanDisplay minPlanWidth="236px">
+      {/* Default card */}
       <PlanDisplay.Card>
         <PlanDisplay.Header
-          subtitle="Punto de venta"
-          title={
-            <Box display="flex" gap="1">
-              <Title as="h3" color="neutral-textLow">
-                Plan
-              </Title>
-              <Title as="h3" color="neutral-textHigh">
-                Básico
-              </Title>
-            </Box>
-          }
-        >
-          <Title as="h5">Suscripción gratuita</Title>
-          <Text fontWeight="bold" fontSize="highlight">
-            1.5% costo por transacción
-          </Text>
-        </PlanDisplay.Header>
+          subtitle="Inicial"
+          title={<PlanDisplay.Price price="Gratis" />}
+        />
         <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Todo lo que necesitas para empezar a vender online.</Text>
+            <Button fullWidth>Comenzar gratis</Button>
+          </Box>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Descuentos personalizados
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Búsqueda de clientes
+            Tu tienda lista para empezar a vender
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta con envío
+            Productos y visitas sin límite
           </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Venta sin stock
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Registro de medio de pago
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Escaneo de producto
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Gestión de caja
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Asignación de vendedor
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Creación de productos durante la venta
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Guardar carritos
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Atajos de teclado
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Medios de pago y envío de Tiendanube
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
-      <PlanDisplay.Card highlighted>
+
+      {/* Card with tag */}
+      <PlanDisplay.Card>
         <PlanDisplay.Header
-          subtitle="Punto de venta"
+          subtitle="Esencial"
+          tag={<Tag appearance="neutral">Plan actual</Tag>}
           title={
-            <Box display="flex" gap="1">
-              <Title as="h3" color="neutral-textLow">
-                Plan
-              </Title>
-              <Title as="h3" color="neutral-textHigh">
-                Avanzado
-              </Title>
-            </Box>
+            <PlanDisplay.Price
+              price="$24.999"
+              previousPrice="$29.999"
+              period="/mes"
+              annualNote={
+                <>
+                  $269.990/año.{" "}
+                  <Text as="span" color="primary-textLow" fontSize="caption">
+                    Ahorra $30.000.
+                  </Text>
+                </>
+              }
+            />
           }
-        >
-          <Title as="h5">$14.999 / mes</Title>
-          <Text fontWeight="bold" fontSize="highlight">
-            0.15% costo por transacción
-          </Text>
-        </PlanDisplay.Header>
+        />
         <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Potenciá tu marca y vendé como una tienda profesional.</Text>
+            <Button fullWidth>Subir de plan</Button>
+          </Box>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Descuentos personalizados
+            Incluye todo lo del plan anterior, más:
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de clientes
+            Carga masiva de productos
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Búsqueda de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta con envío
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta sin stock
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de medio de pago
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Escaneo de producto
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Gestión de caja
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Asignación de vendedor
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Creación de productos durante la venta
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Guardar carritos
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Atajos de teclado
+            Dominio propio
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
-        <PlanDisplay.Footer>
-          <Box
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-            width="100%"
-            gap="2"
-          >
-            <Button appearance="primary">
-              <Text fontSize="base" color="currentColor">
-                Comenzar gratis por 7 días*
-              </Text>
+      </PlanDisplay.Card>
+
+      {/* Featured card with ribbon */}
+      <PlanDisplay.Card ribbonLabel="Más escogido">
+        <PlanDisplay.Header
+          subtitle="Avanzado"
+          title={<PlanDisplay.Price price="$219.999" period="/mes" />}
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Gestión avanzada y control total para tu negocio.</Text>
+            <Button appearance="primary" fullWidth>
+              Subir de plan
             </Button>
-            <Text fontSize="caption">
-              *Al finalizar la prueba podrás elegir cancelar, continuar o
-              cambiar de plan
-            </Text>
           </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Campos personalizados en productos y órdenes
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet
+            icon={<CheckIcon />}
+            badge={<Tag appearance="primary">Nuevo</Tag>}
+          >
+            Hasta 3 tablas de precios mayoristas
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
+            IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+        <PlanDisplay.Footer icon={<CashierIcon />}>
+          <Text>
+            Obtén{" "}
+            <Link
+              as="a"
+              href="#"
+              appearance="primary"
+              textDecoration="underline"
+            >
+              Punto de venta Plus
+            </Link>{" "}
+            extra por $149.90/mes
+          </Text>
         </PlanDisplay.Footer>
+      </PlanDisplay.Card>
+
+      {/* Gradient card */}
+      <PlanDisplay.Card gradient>
+        <PlanDisplay.Header
+          subtitle="Evolución"
+          title={<PlanDisplay.Price price="$439.999" period="/mes" />}
+        />
+        <PlanDisplay.Content>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>La solución completa para escalar sin límites.</Text>
+            <Button fullWidth>Subir de plan</Button>
+          </Box>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Soporte prioritario y ejecutivo de cuenta
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
+            IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
       </PlanDisplay.Card>
     </PlanDisplay>
   ),
 };
 
-export const threePlans: Story = {
-  render: () => (
-    <PlanDisplay>
-      <PlanDisplay.Card>
+type PlaygroundArgs = {
+  showTag: boolean;
+  showDiscount: boolean;
+  showSuffix: boolean;
+  showDescription: boolean;
+  showButton: boolean;
+  showFooter: boolean;
+};
+
+/**
+ * Mirrors the configurable properties of the Figma master component. Each toggle maps to an
+ * optional slot/prop, showing how every part of a plan card is opt-in through composition.
+ */
+export const Playground: StoryObj<PlaygroundArgs> = {
+  args: {
+    showTag: true,
+    showDiscount: true,
+    showSuffix: true,
+    showDescription: true,
+    showButton: true,
+    showFooter: true,
+  },
+  argTypes: {
+    showTag: { control: "boolean" },
+    showDiscount: { control: "boolean" },
+    showSuffix: { control: "boolean" },
+    showDescription: { control: "boolean" },
+    showButton: { control: "boolean" },
+    showFooter: { control: "boolean" },
+  },
+  render: ({
+    showTag,
+    showDiscount,
+    showSuffix,
+    showDescription,
+    showButton,
+    showFooter,
+  }) => (
+    <PlanDisplay minPlanWidth="236px">
+      <PlanDisplay.Card ribbonLabel="Más escogido">
         <PlanDisplay.Header
-          subtitle="Punto de venta"
+          subtitle="Avanzado"
+          tag={showTag ? <Tag appearance="neutral">Plan actual</Tag> : undefined}
           title={
-            <Box display="flex" gap="1">
-              <Title as="h3" color="neutral-textLow">
-                Plan
-              </Title>
-              <Title as="h3" color="neutral-textHigh">
-                Básico
-              </Title>
-            </Box>
+            <PlanDisplay.Price
+              price="$24.999"
+              previousPrice={showDiscount ? "$29.999" : undefined}
+              period={showSuffix ? "/mes" : undefined}
+              annualNote={
+                showDescription ? (
+                  <>
+                    $269.990/año.{" "}
+                    <Text as="span" color="primary-textLow" fontSize="caption">
+                      Ahorra $30.000.
+                    </Text>
+                  </>
+                ) : undefined
+              }
+            />
           }
-        >
-          <Title as="h5">Suscripción gratuita</Title>
-          <Text fontWeight="bold" fontSize="highlight">
-            1.5% costo por transacción
-          </Text>
-        </PlanDisplay.Header>
+        />
         <PlanDisplay.Content>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Descuentos personalizados
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Búsqueda de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta con envío
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Venta sin stock
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Registro de medio de pago
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Escaneo de producto
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Gestión de caja
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Asignación de vendedor
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Creación de productos durante la venta
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Guardar carritos
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Atajos de teclado
-          </PlanDisplay.Bullet>
-        </PlanDisplay.Content>
-      </PlanDisplay.Card>
-      <PlanDisplay.Card>
-        <PlanDisplay.Header
-          subtitle="Punto de venta"
-          title={
-            <Box display="flex" gap="1">
-              <Title as="h3" color="neutral-textLow">
-                Plan
-              </Title>
-              <Title as="h3" color="neutral-textHigh">
-                Emprendedor
-              </Title>
-            </Box>
-          }
-        >
-          <Title as="h5">$6.999 / mes</Title>
-          <Text fontWeight="bold" fontSize="highlight">
-            0.5% costo por transacción
-          </Text>
-        </PlanDisplay.Header>
-        <PlanDisplay.Content>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Descuentos personalizados
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Búsqueda de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta con envío
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta sin stock
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de medio de pago
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Escaneo de producto
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Gestión de caja
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Asignación de vendedor
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Creación de productos durante la venta
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Guardar carritos
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
-            Atajos de teclado
-          </PlanDisplay.Bullet>
-        </PlanDisplay.Content>
-      </PlanDisplay.Card>
-      <PlanDisplay.Card highlighted>
-        <PlanDisplay.Header
-          subtitle="Punto de venta"
-          title={
-            <Box display="flex" gap="1">
-              <Title as="h3" color="neutral-textLow">
-                Plan
-              </Title>
-              <Title as="h3" color="neutral-textHigh">
-                Avanzado
-              </Title>
-            </Box>
-          }
-        >
-          <Title as="h5">$14.999 / mes</Title>
-          <Text fontWeight="bold" fontSize="highlight">
-            0.15% costo por transacción
-          </Text>
-        </PlanDisplay.Header>
-        <PlanDisplay.Content>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Descuentos personalizados
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Búsqueda de clientes
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta con envío
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Venta sin stock
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Registro de medio de pago
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Escaneo de producto
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Gestión de caja
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Asignación de vendedor
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Creación de productos durante la venta
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Guardar carritos
-          </PlanDisplay.Bullet>
-          <PlanDisplay.Bullet icon={<CheckIcon />}>
-            Atajos de teclado
-          </PlanDisplay.Bullet>
-        </PlanDisplay.Content>
-        <PlanDisplay.Footer>
-          <Box
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-            width="100%"
-            gap="2"
-          >
-            <Button appearance="primary">
-              <Text fontSize="base" color="currentColor">
-                Comenzar gratis por 7 días*
-              </Text>
-            </Button>
-            <Text fontSize="caption">
-              *Al finalizar la prueba podrás elegir cancelar, continuar o
-              cambiar de plan
-            </Text>
+          <Box display="flex" flexDirection="column" gap="3" pb="2">
+            <Text>Gestión avanzada y control total para tu negocio.</Text>
+            {showButton && (
+              <Button appearance="primary" fullWidth>
+                Subir de plan
+              </Button>
+            )}
           </Box>
-        </PlanDisplay.Footer>
+          <PlanDisplay.Bullet icon={<CheckIcon />}>
+            Incluye todo lo del plan anterior, más:
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet
+            icon={<CheckIcon />}
+            badge={<Tag appearance="primary">Nuevo</Tag>}
+          >
+            Hasta 3 tablas de precios mayoristas
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
+            IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+        </PlanDisplay.Content>
+        {showFooter && (
+          <PlanDisplay.Footer icon={<CashierIcon />}>
+            <Text>
+              Obtén{" "}
+              <Link
+                as="a"
+                href="#"
+                appearance="primary"
+                textDecoration="underline"
+              >
+                Punto de venta Plus
+              </Link>{" "}
+              extra por $149.90/mes
+            </Text>
+          </PlanDisplay.Footer>
+        )}
       </PlanDisplay.Card>
     </PlanDisplay>
   ),

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
@@ -309,16 +309,18 @@ export const ThreePlans: Story = {
  */
 export const Horizontal: Story = {
   render: () => (
-    <Box style={{ maxWidth: 740 }}>
+    <div style={{ maxWidth: 740 }}>
       <PlanDisplay.Card>
         <Box display="flex" gap="6" alignItems="center">
           {/* Plan info */}
-          <Box
-            display="flex"
-            flexDirection="column"
-            gap="3"
-            justifyContent="center"
-            style={{ flex: "0 0 253px" }}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--nimbus-spacing-3)",
+              justifyContent: "center",
+              flex: "0 0 253px",
+            }}
           >
             <PlanDisplay.Header
               subtitle="Inicial"
@@ -328,21 +330,26 @@ export const Horizontal: Story = {
               <Text>Tudo o que você precisa para começar a vender online.</Text>
               <Button fullWidth>Bajar de plan</Button>
             </Box>
-          </Box>
+          </div>
 
           {/* Vertical divider */}
-          <Box
-            alignSelf="stretch"
-            backgroundColor="neutral-surfaceHighlight"
-            style={{ width: "1px", flexShrink: 0 }}
+          <div
+            style={{
+              alignSelf: "stretch",
+              backgroundColor: "var(--nimbus-colors-neutral-surfaceHighlight)",
+              width: "1px",
+              flexShrink: 0,
+            }}
           />
 
           {/* Feature bullets */}
-          <Box
-            display="flex"
-            flexDirection="column"
-            gap="3"
-            style={{ flex: "1 1 0" }}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "var(--nimbus-spacing-3)",
+              flex: "1 1 0",
+            }}
           >
             <PlanDisplay.Bullet icon={<CheckIcon />}>
               Sua loja autogerenciável e pronta para vender
@@ -353,10 +360,10 @@ export const Horizontal: Story = {
             <PlanDisplay.Bullet icon={<CheckIcon />}>
               Meios de pagamento e envio da Nuvemshop
             </PlanDisplay.Bullet>
-          </Box>
+          </div>
         </Box>
       </PlanDisplay.Card>
-    </Box>
+    </div>
   ),
 };
 
@@ -366,7 +373,7 @@ export const Horizontal: Story = {
  */
 export const HorizontalMobile: Story = {
   render: () => (
-    <Box style={{ maxWidth: 361 }}>
+    <div style={{ maxWidth: 361 }}>
       <PlanDisplay.Card>
         <Box display="flex" flexDirection="column" gap="6">
           {/* Plan info */}
@@ -395,7 +402,7 @@ export const HorizontalMobile: Story = {
           </Box>
         </Box>
       </PlanDisplay.Card>
-    </Box>
+    </div>
   ),
 };
 

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.stories.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { Box, Button, Link, Tag, Text } from "@nimbus-ds/components";
-import { CashierIcon, CheckIcon, GenerativeStarsIcon } from "@nimbus-ds/icons";
+import {
+  CashierIcon,
+  CheckIcon,
+  CloseIcon,
+  GenerativeStarsIcon,
+} from "@nimbus-ds/icons";
 import { PlanDisplay } from "./PlanDisplay";
 
 const meta: Meta<typeof PlanDisplay> = {
@@ -39,6 +44,12 @@ export const Default: Story = {
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
             Medios de pago y envío de Tiendanube
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Carga masiva de productos
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Dominio propio
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
@@ -78,6 +89,12 @@ export const Default: Story = {
           <PlanDisplay.Bullet icon={<CheckIcon />}>
             Dominio propio
           </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Campos personalizados en productos y órdenes
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Hasta 3 tablas de precios mayoristas
+          </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
 
@@ -108,6 +125,9 @@ export const Default: Story = {
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
             IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Soporte prioritario y ejecutivo de cuenta
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
         <PlanDisplay.Footer icon={<CashierIcon />}>
@@ -185,6 +205,9 @@ export const TwoPlans: Story = {
           <PlanDisplay.Bullet icon={<CheckIcon />}>
             Dominio propio
           </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Campos personalizados en productos y órdenes
+          </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
 
@@ -242,6 +265,12 @@ export const ThreePlans: Story = {
           <PlanDisplay.Bullet icon={<CheckIcon />}>
             Medios de pago y envío de Tiendanube
           </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Carga masiva de productos
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Dominio propio
+          </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
 
@@ -271,6 +300,9 @@ export const ThreePlans: Story = {
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<CheckIcon />}>
             Dominio propio
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Campos personalizados en productos y órdenes
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
       </PlanDisplay.Card>
@@ -360,6 +392,9 @@ export const Horizontal: Story = {
             <PlanDisplay.Bullet icon={<CheckIcon />}>
               Meios de pagamento e envio da Nuvemshop
             </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+              Domínio próprio
+            </PlanDisplay.Bullet>
           </div>
         </Box>
       </PlanDisplay.Card>
@@ -398,6 +433,9 @@ export const HorizontalMobile: Story = {
             </PlanDisplay.Bullet>
             <PlanDisplay.Bullet icon={<CheckIcon />}>
               Meios de pagamento e envio da Nuvemshop
+            </PlanDisplay.Bullet>
+            <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+              Domínio próprio
             </PlanDisplay.Bullet>
           </Box>
         </Box>
@@ -498,6 +536,9 @@ export const Playground: StoryObj<PlaygroundArgs> = {
           </PlanDisplay.Bullet>
           <PlanDisplay.Bullet icon={<GenerativeStarsIcon />}>
             IA ilimitada para potenciar tu gestión
+          </PlanDisplay.Bullet>
+          <PlanDisplay.Bullet icon={<CloseIcon />} disabled>
+            Soporte prioritario y ejecutivo de cuenta
           </PlanDisplay.Bullet>
         </PlanDisplay.Content>
         {showFooter && (

--- a/packages/react/src/components/PlanDisplay/src/planDisplay.types.ts
+++ b/packages/react/src/components/PlanDisplay/src/planDisplay.types.ts
@@ -7,6 +7,7 @@ import {
   PlanDisplayCardContent,
   PlanDisplayCardFooter,
   PlanDisplayCardHeader,
+  PlanDisplayCardPrice,
   PlanDisplayCardSpacing,
 } from "./components";
 
@@ -25,6 +26,11 @@ export interface PlanDisplayComponents {
    * an optional children where additional information can be displayed.
    */
   Header: typeof PlanDisplayCardHeader;
+
+  /**
+   * The price component of the plan display card. It renders the current price and optionally a previous price (with line-through), a billing period suffix and an annual note.
+   */
+  Price: typeof PlanDisplayCardPrice;
 
   /**
    * The content component of the plan display card. This component is used to display the main content of the plan, such as the plan bullet points.


### PR DESCRIPTION
> **Component contribution pilot:** this PR is historical evidence used to reconstruct [issue #185](https://github.com/TiendaNube/nimbus-patterns/issues/185). It is not the construction PR for the pilot and must not receive further pilot work. Construction starts from the current default branch and produces a completely new draft PR from the agreed issue spec.

Make the Plans 2.0 layout the canonical PlanDisplay, matching the Figma master component:

- Card: default level-2 shadow, plus opt-in `ribbonLabel` and `gradient` variants; remove the legacy `highlighted` prop (breaking change)
- Add `PlanDisplay.Price` subcomponent (current/previous price, period, annual note)
- Add `tag` slot on Header, `badge` slot on Bullet, `icon` slot on Footer
- Update stories, README, CHANGELOG and version bump

## Type

- [ ] Bugfix 🐛
- [ ] New feature 🌈
- [ ] Change request 🤓
- [ ] Documentation 📚
- [ ] Tech debt 👩‍💻

## Changes proposed ✔️

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Reworked PlanDisplay component with Plans 2.0 canonical layout
  * Added new component slots: tag, badge, and icon support
  * Introduced PlanDisplay.Price subcomponent
  * New card visual variants: ribbonLabel and gradient

* **Breaking Changes**
  * Removed highlighted prop; use ribbonLabel or gradient instead

* **Documentation**
  * Updated README with subcomponents guide and usage examples
  * Added Plans 2.0 example section
  * Enhanced Storybook with interactive playground

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
