### PR TITLE
feat(nav-tabs): add ai-generative appearance to NavTabs.Item

### DIFF
--- a/.yarn/versions/cb061169.yml
+++ b/.yarn/versions/cb061169.yml
@@ -1,5 +1,6 @@
 releases:
   "@nimbus-ds/nav-tabs": minor
+  "@nimbus-ds/patterns": minor
 
 declined:
   - nimbus-patterns

--- a/.yarn/versions/cb061169.yml
+++ b/.yarn/versions/cb061169.yml
@@ -1,0 +1,5 @@
+releases:
+  "@nimbus-ds/nav-tabs": minor
+
+declined:
+  - nimbus-patterns

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Nimbus is an open-source Design System created by Tiendanube / Nuvesmhop's team to empower and enhance more stories every day, with simplicity, accessibility, consistency and performance.
 
+## 2026-07-15 `1.37.0`
+
+#### 🎉 New features
+
+- `NavTabs`: Added an `appearance` prop to `NavTabs.Item`, with an `"ai-generative"` variant that renders a gradient border and a fixed AI icon for AI entry points such as an assistant button. ([#176](https://github.com/TiendaNube/nimbus-patterns/pull/176) by [@jffs](https://github.com/jffs))
+
 ## 2026-06-25 `1.36.0`
 
 #### 🎉 New features

--- a/packages/react/src/components/NavTabs/CHANGELOG.md
+++ b/packages/react/src/components/NavTabs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 The NavTabs component represents the main navigation dock for an application on a mobile device, including up to 5 tabs or buttons for different sections. The component has a fixed position on the bottom of the screen.
 
+## 2026-07-15 `1.4.0`
+
+#### 🎉 New features
+
+- Added an `appearance` prop to `NavTabs.Item`, with an `"ai-generative"` variant that renders a gradient border and a fixed AI icon for AI entry points such as an assistant button. ([#176](https://github.com/TiendaNube/nimbus-patterns/pull/176) by [@jffs](https://github.com/jffs))
+
 ## 2026-03-04 `1.2.7`
 
 #### 🐛 Bug fixes

--- a/packages/react/src/components/NavTabs/package.json
+++ b/packages/react/src/components/NavTabs/package.json
@@ -31,8 +31,5 @@
   },
   "dependencies": {
     "@nimbus-ds/tokens": "^9.5.0"
-  },
-  "devDependencies": {
-    "@nimbus-ds/icons": "^1.15.1"
   }
 }

--- a/packages/react/src/components/NavTabs/package.json
+++ b/packages/react/src/components/NavTabs/package.json
@@ -17,6 +17,7 @@
   },
   "peerDependencies": {
     "@nimbus-ds/components": "^5",
+    "@nimbus-ds/icons": "^1.15.1",
     "react": "^16.8 || ^17.0 || ^18.0 || ^19.0",
     "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0"
   },
@@ -28,7 +29,11 @@
   "bugs": {
     "url": "https://github.com/TiendaNube/nimbus-patterns/issues"
   },
+  "dependencies": {
+    "@nimbus-ds/styles": "^9.11.0",
+    "@nimbus-ds/tokens": "^9.5.0"
+  },
   "devDependencies": {
-    "@nimbus-ds/icons": "^1"
+    "@nimbus-ds/icons": "^1.15.1"
   }
 }

--- a/packages/react/src/components/NavTabs/package.json
+++ b/packages/react/src/components/NavTabs/package.json
@@ -30,7 +30,6 @@
     "url": "https://github.com/TiendaNube/nimbus-patterns/issues"
   },
   "dependencies": {
-    "@nimbus-ds/styles": "^9.11.0",
     "@nimbus-ds/tokens": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
@@ -1,48 +1,103 @@
 import React from "react";
 
 import { Icon, Box } from "@nimbus-ds/components";
+import { GenerativeStarsIcon } from "@nimbus-ds/icons";
+import { useTheme } from "@nimbus-ds/styles";
+import tokens from "@nimbus-ds/tokens/dist/js/tokens";
 
 import { NavTabsItemProps } from "./navTabsItem.types";
 
+const Badge: React.FC = () => (
+  <Box
+    borderRadius="full"
+    backgroundColor="primary-interactive"
+    height=".25rem"
+    position="absolute"
+    right=".25rem"
+    top=".25rem"
+    width=".25rem"
+  />
+);
+
 const NavTabsItem: React.FC<NavTabsItemProps> = ({
   style: _style,
+  appearance = "neutral",
   icon,
   active = false,
   badge = false,
   onClick,
   ariaLabel,
   ...rest
-}: NavTabsItemProps) => (
-  <Box
-    {...rest}
-    style={_style}
-    backgroundColor={active ? "primary-surface" : "transparent"}
-    borderColor="transparent"
-    borderRadius="2"
-    cursor="pointer"
-    as="button"
-    type="button"
-    p="2-5"
-    position="relative"
-    onClick={onClick}
-    aria-label={ariaLabel}
-  >
-    <Icon
-      source={icon}
-      color={active ? "primary-interactive" : "primary-textLow"}
-    />
-    {badge && (
-      <Box
-        borderRadius="full"
-        backgroundColor="primary-interactive"
-        height=".25rem"
-        position="absolute"
-        right=".25rem"
-        top=".25rem"
-        width=".25rem"
+}: NavTabsItemProps) => {
+  const { currentTheme } = useTheme();
+  const theme =
+    currentTheme === "base" || currentTheme === "next" ? "light" : "dark";
+
+  if (appearance === "ai-generative") {
+    const gradient = `linear-gradient(66deg, ${tokens.color[theme].aiGradient["blue-high"].value} 0%, ${tokens.color[theme].aiGradient["purple-high"].value} 50%, ${tokens.color[theme].aiGradient["pink-high"].value} 100%)`;
+
+    return (
+      // Plain div, not Box: this wrapper is purely decorative (no `as`, no
+      // a11y role) and needs an arbitrary background-image + exact padding
+      // for the gradient-border effect — going through Box's CSS-in-JS
+      // sprinkles for that combination produced unreproducible rendering
+      // bugs. The interactive button below stays a Box.
+      <div
+        style={{
+          display: "inline-flex",
+          backgroundImage: gradient,
+          // 10px = the inner button's 8px radius (borderRadius="2") + the
+          // 2px padding below, so the gradient ring is concentric.
+          borderRadius: "10px",
+          padding: "2px",
+        }}
+      >
+        <Box
+          {...rest}
+          style={_style}
+          backgroundColor="neutral-background"
+          borderColor="transparent"
+          borderRadius="2"
+          cursor="pointer"
+          as="button"
+          type="button"
+          p="2-5"
+          position="relative"
+          onClick={onClick}
+          aria-label={ariaLabel}
+        >
+          <Icon
+            source={<GenerativeStarsIcon size="medium" />}
+            color="ai-generative"
+          />
+          {badge && <Badge />}
+        </Box>
+      </div>
+    );
+  }
+
+  return (
+    <Box
+      {...rest}
+      style={_style}
+      backgroundColor={active ? "primary-surface" : "transparent"}
+      borderColor="transparent"
+      borderRadius="2"
+      cursor="pointer"
+      as="button"
+      type="button"
+      p="2-5"
+      position="relative"
+      onClick={onClick}
+      aria-label={ariaLabel}
+    >
+      <Icon
+        source={icon}
+        color={active ? "primary-interactive" : "primary-textLow"}
       />
-    )}
-  </Box>
-);
+      {badge && <Badge />}
+    </Box>
+  );
+};
 
 export { NavTabsItem };

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
@@ -6,6 +6,16 @@ import tokens from "@nimbus-ds/tokens/dist/js/tokens";
 
 import { NavTabsItemProps } from "./navTabsItem.types";
 
+const interactiveButtonProps = {
+  borderColor: "transparent",
+  borderRadius: "2",
+  cursor: "pointer",
+  as: "button",
+  type: "button",
+  p: "2-5",
+  position: "relative",
+} as const;
+
 const Badge: React.FC = () => (
   <Box
     borderRadius="full"
@@ -52,15 +62,9 @@ const NavTabsItem: React.FC<NavTabsItemProps> = ({
       >
         <Box
           {...rest}
+          {...interactiveButtonProps}
           style={_style}
           backgroundColor="neutral-background"
-          borderColor="transparent"
-          borderRadius="2"
-          cursor="pointer"
-          as="button"
-          type="button"
-          p="2-5"
-          position="relative"
           onClick={onClick}
           aria-label={ariaLabel}
         >
@@ -77,15 +81,9 @@ const NavTabsItem: React.FC<NavTabsItemProps> = ({
   return (
     <Box
       {...rest}
+      {...interactiveButtonProps}
       style={_style}
       backgroundColor={active ? "primary-surface" : "transparent"}
-      borderColor="transparent"
-      borderRadius="2"
-      cursor="pointer"
-      as="button"
-      type="button"
-      p="2-5"
-      position="relative"
       onClick={onClick}
       aria-label={ariaLabel}
     >

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
@@ -43,6 +43,10 @@ const NavTabsItem: React.FC<NavTabsItemProps> = ({
     // brand accent), so no theme lookup is needed here.
     const { aiGradient } = tokens.color.light;
     const gradient = `linear-gradient(66deg, ${aiGradient["blue-high"].value} 0%, ${aiGradient["purple-high"].value} 50%, ${aiGradient["pink-high"].value} 100%)`;
+    // Same token as the inner button's borderRadius="2", read from the
+    // token module (not a CSS var — those aren't reliably resolvable here)
+    // so the wrapper's radius can't drift out of sync with the button's.
+    const buttonRadius = tokens.shape.border.radius["2"].value;
 
     return (
       // Plain div, not Box: this wrapper is purely decorative (no `as`, no
@@ -54,9 +58,9 @@ const NavTabsItem: React.FC<NavTabsItemProps> = ({
         style={{
           display: "inline-flex",
           backgroundImage: gradient,
-          // 10px = the inner button's 8px radius (borderRadius="2") + the
-          // 2px padding below, so the gradient ring is concentric.
-          borderRadius: "10px",
+          // Button radius + the 2px padding below, so the gradient ring
+          // stays concentric with the button's corners.
+          borderRadius: `calc(${buttonRadius} + 2px)`,
           padding: "2px",
         }}
       >

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/NavTabsItem.tsx
@@ -2,7 +2,6 @@ import React from "react";
 
 import { Icon, Box } from "@nimbus-ds/components";
 import { GenerativeStarsIcon } from "@nimbus-ds/icons";
-import { useTheme } from "@nimbus-ds/styles";
 import tokens from "@nimbus-ds/tokens/dist/js/tokens";
 
 import { NavTabsItemProps } from "./navTabsItem.types";
@@ -29,12 +28,11 @@ const NavTabsItem: React.FC<NavTabsItemProps> = ({
   ariaLabel,
   ...rest
 }: NavTabsItemProps) => {
-  const { currentTheme } = useTheme();
-  const theme =
-    currentTheme === "base" || currentTheme === "next" ? "light" : "dark";
-
   if (appearance === "ai-generative") {
-    const gradient = `linear-gradient(66deg, ${tokens.color[theme].aiGradient["blue-high"].value} 0%, ${tokens.color[theme].aiGradient["purple-high"].value} 50%, ${tokens.color[theme].aiGradient["pink-high"].value} 100%)`;
+    // aiGradient stops are identical across light/dark themes (a fixed AI
+    // brand accent), so no theme lookup is needed here.
+    const { aiGradient } = tokens.color.light;
+    const gradient = `linear-gradient(66deg, ${aiGradient["blue-high"].value} 0%, ${aiGradient["purple-high"].value} 50%, ${aiGradient["pink-high"].value} 100%)`;
 
     return (
       // Plain div, not Box: this wrapper is purely decorative (no `as`, no

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
+import tokens from "@nimbus-ds/tokens/dist/js/tokens";
 
 import { NavTabsItem } from "./NavTabsItem";
 import {
@@ -126,7 +127,9 @@ describe("GIVEN <NavTabsItem />", () => {
       expect(wrapper.tagName).toBe("DIV");
       expect(wrapper.style.display).toBe("inline-flex");
       expect(wrapper.style.padding).toBe("2px");
-      expect(wrapper.style.borderRadius).toBe("10px");
+      expect(wrapper.style.borderRadius).toBe(
+        `calc(${tokens.shape.border.radius["2"].value} + 2px)`
+      );
       // jsdom's style engine can't validate/store `linear-gradient()` on
       // background-image (a known jsdom limitation), so the gradient itself
       // isn't asserted here — verified visually in Storybook instead.

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
@@ -2,18 +2,38 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 import { NavTabsItem } from "./NavTabsItem";
-import { NavTabsItemProps } from "./navTabsItem.types";
+import {
+  NavTabsItemNeutralProperties,
+  NavTabsItemAIGenerativeProperties,
+} from "./navTabsItem.types";
 
 const iconElement = "Icon element";
 const mockedClickFunction = jest.fn();
 
 const makeSut = (
-  rest: Omit<NavTabsItemProps, "icon" | "onClick" | "ariaLabel">
+  rest: Omit<NavTabsItemNeutralProperties, "icon" | "onClick" | "ariaLabel">
 ) => {
   render(
     <NavTabsItem
       {...rest}
       icon={iconElement}
+      data-testid="nav-tabs-item-element"
+      onClick={mockedClickFunction}
+      ariaLabel="nav-tabs-item"
+    />
+  );
+};
+
+const makeAISut = (
+  rest: Omit<
+    NavTabsItemAIGenerativeProperties,
+    "appearance" | "onClick" | "ariaLabel"
+  > = {}
+) => {
+  render(
+    <NavTabsItem
+      {...rest}
+      appearance="ai-generative"
       data-testid="nav-tabs-item-element"
       onClick={mockedClickFunction}
       ariaLabel="nav-tabs-item"
@@ -39,6 +59,78 @@ describe("GIVEN <NavTabsItem />", () => {
       const buttonClick = screen.getByRole<HTMLButtonElement>("button");
       fireEvent.click(buttonClick);
       expect(mockedClickFunction).toHaveBeenCalled();
+    });
+  });
+
+  describe('WHEN rendered with appearance="ai-generative"', () => {
+    it("SHOULD render the frozen AI icon and ignore any icon passed at runtime", () => {
+      const props = {
+        appearance: "ai-generative",
+        icon: iconElement,
+        onClick: mockedClickFunction,
+        ariaLabel: "nav-tabs-item",
+        // Simulates a consumer bypassing the `icon?: never` type constraint.
+      } as unknown as NavTabsItemAIGenerativeProperties;
+      render(<NavTabsItem {...props} />);
+
+      expect(screen.queryByText(iconElement)).toBeNull();
+      const button = screen.getByRole("button");
+      expect(button.querySelector("svg")).not.toBeNull();
+    });
+
+    it("SHOULD render the aria label correctly", () => {
+      makeAISut();
+      const button = screen.getByRole("button");
+      expect(button.getAttribute("aria-label")).toBe("nav-tabs-item");
+    });
+
+    it("SHOULD execute the onClick correctly", () => {
+      makeAISut();
+      const buttonClick = screen.getByRole<HTMLButtonElement>("button");
+      fireEvent.click(buttonClick);
+      expect(mockedClickFunction).toHaveBeenCalled();
+    });
+
+    it("SHOULD render the badge when requested", () => {
+      const { container: withoutBadge } = render(
+        <NavTabsItem
+          appearance="ai-generative"
+          onClick={mockedClickFunction}
+          ariaLabel="nav-tabs-item"
+        />
+      );
+      const { container: withBadge } = render(
+        <NavTabsItem
+          appearance="ai-generative"
+          badge
+          onClick={mockedClickFunction}
+          ariaLabel="nav-tabs-item"
+        />
+      );
+
+      expect(withBadge.querySelectorAll("div").length).toBeGreaterThan(
+        withoutBadge.querySelectorAll("div").length
+      );
+    });
+
+    it("SHOULD wrap the button in a gradient border that hugs its content", () => {
+      const { container } = render(
+        <NavTabsItem
+          appearance="ai-generative"
+          onClick={mockedClickFunction}
+          ariaLabel="nav-tabs-item"
+        />
+      );
+
+      const wrapper = container.firstChild as HTMLElement;
+      expect(wrapper.tagName).toBe("DIV");
+      expect(wrapper.style.display).toBe("inline-flex");
+      expect(wrapper.style.padding).toBe("2px");
+      expect(wrapper.style.borderRadius).toBe("10px");
+      // jsdom's style engine can't validate/store `linear-gradient()` on
+      // background-image (a known jsdom limitation), so the gradient itself
+      // isn't asserted here — verified visually in Storybook instead.
+      expect(wrapper.querySelector("button")).not.toBeNull();
     });
   });
 });

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
@@ -123,7 +123,7 @@ describe("GIVEN <NavTabsItem />", () => {
         />
       );
 
-      expect(withBadge.querySelectorAll("div").length).toBe(
+      expect(withBadge.querySelectorAll("div")).toHaveLength(
         withoutBadge.querySelectorAll("div").length + 1
       );
     });

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
@@ -92,6 +92,20 @@ describe("GIVEN <NavTabsItem />", () => {
       expect(mockedClickFunction).toHaveBeenCalled();
     });
 
+    it("SHOULD reject `active` at the type level", () => {
+      render(
+        // @ts-expect-error `active` is not accepted when appearance="ai-generative"
+        <NavTabsItem
+          active
+          appearance="ai-generative"
+          onClick={mockedClickFunction}
+          ariaLabel="nav-tabs-item"
+        />
+      );
+
+      expect(screen.getByRole("button")).toBeDefined();
+    });
+
     it("SHOULD render the badge when requested", () => {
       const { container: withoutBadge } = render(
         <NavTabsItem

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.spec.tsx
@@ -108,8 +108,8 @@ describe("GIVEN <NavTabsItem />", () => {
         />
       );
 
-      expect(withBadge.querySelectorAll("div").length).toBeGreaterThan(
-        withoutBadge.querySelectorAll("div").length
+      expect(withBadge.querySelectorAll("div").length).toBe(
+        withoutBadge.querySelectorAll("div").length + 1
       );
     });
 

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.stories.tsx
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.stories.tsx
@@ -24,3 +24,11 @@ export const basic: Story = {
     ariaLabel: "Home",
   },
 };
+
+export const aiGenerative: Story = {
+  args: {
+    appearance: "ai-generative",
+    onClick: () => false,
+    ariaLabel: "Lumi assistant",
+  },
+};

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
@@ -1,9 +1,22 @@
 import { ReactNode, HTMLAttributes } from "react";
 import { BoxProperties } from "@nimbus-ds/components";
 
+/**
+ * Flat shape of NavTabs.Item's props, kept as a plain interface (not the
+ * discriminated union below) because the docs generator (@nimbus-ds/scripts)
+ * looks up a schema by the literal name `NavTabsItemProperties` and can't
+ * introspect a union type. NavTabsItemProps is what actually types the
+ * component and enforces the `icon`/`appearance` constraint at compile time.
+ */
 export interface NavTabsItemProperties {
   /**
-   * Icon element to be rendered inside the button.
+   * Visual variant of the button.
+   * "ai-generative" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.
+   * @default "neutral"
+   */
+  appearance?: "neutral" | "ai-generative";
+  /**
+   * Icon element to be rendered inside the button. Ignored when `appearance` is "ai-generative".
    * @TJS-type React.ReactNode
    */
   icon: ReactNode;
@@ -26,6 +39,56 @@ export interface NavTabsItemProperties {
   ariaLabel: string;
 }
 
-export type NavTabsItemProps = NavTabsItemProperties &
+interface NavTabsItemBaseProperties {
+  /**
+   * Controls whether the button is active or not.
+   */
+  active?: boolean;
+  /**
+   * Displays a small badge on top of the button.
+   */
+  badge?: boolean;
+  /**
+   * Function executed on click.
+   * @TJS-type onClick: () => void;
+   */
+  onClick: () => void;
+  /**
+   * Text label used for accessibility.
+   */
+  ariaLabel: string;
+}
+
+export interface NavTabsItemNeutralProperties
+  extends NavTabsItemBaseProperties {
+  /**
+   * Visual variant of the button.
+   * "ai-generative" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.
+   * @default "neutral"
+   */
+  appearance?: "neutral";
+  /**
+   * Icon element to be rendered inside the button.
+   * @TJS-type React.ReactNode
+   */
+  icon: ReactNode;
+}
+
+export interface NavTabsItemAIGenerativeProperties
+  extends NavTabsItemBaseProperties {
+  /**
+   * Visual variant of the button.
+   * "ai-generative" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.
+   * @default "neutral"
+   */
+  appearance: "ai-generative";
+  icon?: never;
+}
+
+export type NavTabsItemVariantProperties =
+  | NavTabsItemNeutralProperties
+  | NavTabsItemAIGenerativeProperties;
+
+export type NavTabsItemProps = NavTabsItemVariantProperties &
   Omit<BoxProperties, "onClick"> &
   Omit<HTMLAttributes<HTMLElement>, "color">;

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
@@ -79,9 +79,10 @@ export interface NavTabsItemAIGenerativeProperties
   /**
    * Visual variant of the button.
    * "ai-generative" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.
-   * @default "neutral"
    */
   appearance: "ai-generative";
+  // No custom icon: this appearance always renders its own frozen AI icon
+  // (GenerativeStarsIcon), so a consumer-provided icon is disallowed.
   icon?: never;
   // No active state: the AI treatment (gradient border + frozen icon)
   // never changes, and the one real usage (the Lumi nav entry point)

--- a/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
+++ b/packages/react/src/components/NavTabs/src/components/NavTabsItem/navTabsItem.types.ts
@@ -21,7 +21,7 @@ export interface NavTabsItemProperties {
    */
   icon: ReactNode;
   /**
-   * Controls whether the button is active or not.
+   * Controls whether the button is active or not. Not accepted when `appearance` is "ai-generative".
    */
   active?: boolean;
   /**
@@ -75,7 +75,7 @@ export interface NavTabsItemNeutralProperties
 }
 
 export interface NavTabsItemAIGenerativeProperties
-  extends NavTabsItemBaseProperties {
+  extends Omit<NavTabsItemBaseProperties, "active"> {
   /**
    * Visual variant of the button.
    * "ai-generative" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.
@@ -83,6 +83,11 @@ export interface NavTabsItemAIGenerativeProperties
    */
   appearance: "ai-generative";
   icon?: never;
+  // No active state: the AI treatment (gradient border + frozen icon)
+  // never changes, and the one real usage (the Lumi nav entry point)
+  // isn't visible while its own panel — the thing "active" would
+  // reflect — is open.
+  active?: never;
 }
 
 export type NavTabsItemVariantProperties =

--- a/packages/react/src/components/NavTabs/src/navTabs.docs.json
+++ b/packages/react/src/components/NavTabs/src/navTabs.docs.json
@@ -16,10 +16,18 @@
   "subComponents": [
     {
       "name": "NavTabs.Item",
-      "totalProps": 5,
+      "totalProps": 6,
       "props": [
         {
-          "description": "Icon element to be rendered inside the button.",
+          "description": "Visual variant of the button.\n\"ai-generative\" renders a fixed AI icon with a gradient border and does not accept a custom `icon`.",
+          "default": "neutral",
+          "enum": ["ai-generative", "neutral"],
+          "type": "string",
+          "title": "appearance",
+          "required": false
+        },
+        {
+          "description": "Icon element to be rendered inside the button. Ignored when `appearance` is \"ai-generative\".",
           "type": "React.ReactNode",
           "title": "icon",
           "required": true

--- a/packages/react/src/components/NavTabs/src/navTabs.docs.json
+++ b/packages/react/src/components/NavTabs/src/navTabs.docs.json
@@ -33,7 +33,7 @@
           "required": true
         },
         {
-          "description": "Controls whether the button is active or not.",
+          "description": "Controls whether the button is active or not. Not accepted when `appearance` is \"ai-generative\".",
           "type": "boolean",
           "title": "active",
           "required": false

--- a/packages/react/src/components/NavTabs/src/navTabs.stories.tsx
+++ b/packages/react/src/components/NavTabs/src/navTabs.stories.tsx
@@ -11,6 +11,27 @@ const meta: Meta<typeof NavTabs> = {
     children: { control: { disable: true } },
   },
   tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      // NavTabs uses `position: fixed`, which targets the real browser
+      // viewport unless an ancestor establishes a new containing block.
+      // Storybook's Docs page renders stories inline rather than in a
+      // full-height iframe (unlike Canvas), so without this the bar
+      // escapes the small preview box and it renders empty. `transform`
+      // creates that containing block; the fixed height gives the
+      // preview box something to show (fixed content adds no flow height).
+      <div
+        style={{
+          position: "relative",
+          height: "80px",
+          overflow: "hidden",
+          transform: "translateZ(0)",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;

--- a/packages/react/src/components/NavTabs/src/navTabs.stories.tsx
+++ b/packages/react/src/components/NavTabs/src/navTabs.stories.tsx
@@ -46,3 +46,39 @@ export const basic: Story = {
     ),
   },
 };
+
+export const withAIGenerativeItem: Story = {
+  args: {
+    children: (
+      <>
+        <NavTabs.Item
+          active
+          icon={<HomeIcon size="medium" />}
+          onClick={() => false}
+          ariaLabel="Home"
+        />
+        <NavTabs.Item
+          badge
+          icon={<MoneyIcon size="medium" />}
+          onClick={() => false}
+          ariaLabel="Orders"
+        />
+        <NavTabs.Item
+          icon={<TagIcon size="medium" />}
+          onClick={() => false}
+          ariaLabel="Products"
+        />
+        <NavTabs.Item
+          icon={<MenuIcon size="medium" />}
+          onClick={() => false}
+          ariaLabel="Menu"
+        />
+        <NavTabs.Item
+          appearance="ai-generative"
+          onClick={() => false}
+          ariaLabel="Lumi assistant"
+        />
+      </>
+    ),
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,9 +3732,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/nav-tabs@workspace:packages/react/src/components/NavTabs"
   dependencies:
-    "@nimbus-ds/icons": ^1
+    "@nimbus-ds/icons": ^1.15.1
+    "@nimbus-ds/styles": ^9.11.0
+    "@nimbus-ds/tokens": ^9.5.0
   peerDependencies:
     "@nimbus-ds/components": ^5
+    "@nimbus-ds/icons": ^1.15.1
     react: ^16.8 || ^17.0 || ^18.0 || ^19.0
     react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,7 +3733,6 @@ __metadata:
   resolution: "@nimbus-ds/nav-tabs@workspace:packages/react/src/components/NavTabs"
   dependencies:
     "@nimbus-ds/icons": ^1.15.1
-    "@nimbus-ds/styles": ^9.11.0
     "@nimbus-ds/tokens": ^9.5.0
   peerDependencies:
     "@nimbus-ds/components": ^5

--- a/yarn.lock
+++ b/yarn.lock
@@ -3732,7 +3732,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@nimbus-ds/nav-tabs@workspace:packages/react/src/components/NavTabs"
   dependencies:
-    "@nimbus-ds/icons": ^1.15.1
     "@nimbus-ds/tokens": ^9.5.0
   peerDependencies:
     "@nimbus-ds/components": ^5


### PR DESCRIPTION
## Summary
- Adds an `appearance` prop (`"neutral" | "ai-generative"`) to `NavTabs.Item` to mark AI entry points (e.g. the Lumi assistant) with a gradient border and a frozen `GenerativeStarsIcon`, natively in the pattern.
- The `icon` prop is required for `appearance="neutral"` (default, unchanged behavior) and rejected at the type level for `appearance="ai-generative"` — the AI icon can't be swapped by consumers.
- Gradient border is composed from `aiGradient` tokens (theme-aware), no changes needed to `@nimbus-ds/components`.
- Not a breaking change — `appearance` is optional and defaults to today's behavior.

Closes #174. Unblocks `services-new-admin` to delete its `NavTabsItemAI.tsx`/`.scss` workaround (referenced in that issue) in favor of `<NavTabs.Item appearance="ai-generative" ... />`.

## Test plan
- [x] `yarn types:check` clean
- [x] `yarn lint` clean
- [x] `yarn test` — 9/9 tests in `NavTabsItem`/`NavTabs` passing (icon rendering, aria-label, onClick, AI icon frozen/ignoring custom icon, badge, gradient wrapper shape)
- [x] `yarn build:docs` — `navTabs.docs.json` reflects the new `appearance` prop
- [x] Verified visually in Storybook (headless Chrome screenshot): gradient border renders with concentric rounded corners, icon gradient fill matches the border, and the item sits correctly sized among neutral items in the navbar row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI-generative appearance for navigation tab items.
  * AI-generative items display a branded gradient treatment and dedicated icon.
  * Added support for badges and accessible labels in the new appearance.
  * Added Storybook examples demonstrating AI-generative navigation items.
* **Tests**
  * Added coverage for rendering, accessibility, interactions, badges, and styling of AI-generative items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->