### PR TITLE
chore(release): re-trigger @nimbus-ds/patterns publish as 1.38.0

### DIFF
--- a/.yarn/versions/3f9c1a7e.yml
+++ b/.yarn/versions/3f9c1a7e.yml
@@ -1,0 +1,5 @@
+releases:
+  "@nimbus-ds/patterns": 1.38.0
+
+declined:
+  - nimbus-patterns

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This is the log of notable changes to the Nimbus Patterns that are developer-facing.
 Package-specific changes not released in any package will be added here just before the release. Until then, you can find them in changelogs of the individual packages (see [packages](./packages) directory).
 
+## 2026-07-30
+
+#### 🐛 Bug fixes
+
+- Re-triggered the release of `@nimbus-ds/patterns` as `1.38.0`. The `1.37.0` (`NavTabs.Item` `appearance`) and `1.38.0` (`BottomSheet`) releases never reached npm: the automated `feat: publish release` pull requests were left unmerged, so `master` stayed on `1.36.0` and every publish run recomputed the same `1.36.0`, which `--tolerate-republish` then skipped silently. ([#177](https://github.com/TiendaNube/nimbus-patterns/pull/177) by [@harrytiendanube](https://github.com/harrytiendanube))
+
 ## 2026-01-15
 
 #### 🎉 New features


### PR DESCRIPTION
## Summary

`@nimbus-ds/patterns` is stuck on **1.36.0** (published 2026-07-14). Neither `1.37.0` (`NavTabs.Item` `appearance="ai-generative"`, #176) nor `1.38.0` (`BottomSheet`, #177) ever reached npm — the published `1.36.0` tarball contains no `BottomSheet` at all.

**Root cause:** since #158 the publish workflow no longer commits the version bumps to `master`; it opens a `feat: publish release` PR. Those PRs were left unmerged (#166, #175, #178), so `packages/react/package.json` stayed on `1.35.1` and every publish run recomputed the same `minor` → `1.36.0`. `publish:npm:stable` uses `--tolerate-republish`, so npm's rejection was swallowed and the job stayed green:

```
[@nimbus-ds/patterns]: YN0000: Registry already knows about version 1.36.0; skipping.
```

(run [30485866953](https://github.com/TiendaNube/nimbus-patterns/actions/runs/30485866953), the publish for #177). `@nimbus-ds/bottom-sheet@2.0.0` published fine because it was a brand-new package name.

#179 has since been merged, so `master` is now in sync at `1.36.0` with no pending version files.

## What this PR does

- Adds `.yarn/versions/3f9c1a7e.yml` declaring an **explicit `1.38.0`** for `@nimbus-ds/patterns` (not `minor`, which would land on `1.37.0`). Both missing changes ship in a single release, and the number matches the entries already written in `packages/react/CHANGELOG.md`.
- Adds a root `CHANGELOG.md` entry recording the missed release.

The `CHANGELOG.md` change is not cosmetic — `publish.yml` has `paths-ignore` on `**/package.json`, `.yarn/versions/**` and `**/*.docs.json`, so a PR touching only the version file would **not** trigger `publish-release`.

## Follow-up (not in this PR)

This will recur on the next release unless the loop is closed:

- Auto-merge the `feat: publish release` PR (or go back to committing bumps straight to `master`, as before #158). Also worth closing the stale #166, #175, #178.
- Add a post-publish guard that compares the packages listed in the consumed `.yarn/versions/*.yml` against npm and **fails** when one was skipped as a republish. `--tolerate-republish` is still needed for the workspaces without a declared bump, but never for those that had one.

## Test plan

- [x] `master` verified at `1.36.0` with `.yarn/versions/` empty, so the explicit `1.38.0` applies cleanly
- [x] Confirmed `@nimbus-ds/patterns@1.36.0` on npm has no `BottomSheet` in `dist/`
- [ ] After merge: `publish-release` runs and `@nimbus-ds/patterns@1.38.0` publishes with `BottomSheet` + the `NavTabs` `ai-generative` appearance
- [ ] After merge: **merge the resulting `feat: publish release` PR** so `master` lands on `1.38.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a changelog entry documenting the re-triggered `@nimbus-ds/patterns` 1.38.0 release.
  * Documented the unpublished 1.37.0 and 1.38.0 releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->